### PR TITLE
🔧 Add .global.extraEnvironmentVars to Helm

### DIFF
--- a/deployments/sdm-relay/README.md
+++ b/deployments/sdm-relay/README.md
@@ -74,6 +74,7 @@ The following table lists the configurable parameters of the strongDM relay/gate
 | .global.deployment.repository | The image you'd like to use for the strongDM gateway/relay. | quay.io/sdmrepo/relay | &#9745; |
 | .global.deployment.tag | The tag for the image you'd like to use for the strongDM gateway/relay. | latest | &#9745; |
 | .global.deployment.imagePullPolicy | The policy for pulling a new image from the repo. | Always | &#9745; |
+| .global.extraEnvironmentVars | Inject extra environment vars in the format key:value, if populated | None | &#9744; |
 | .configmap.SDM_ORCHESTRATOR_PROBES | If you'd like to have a liveliness probe for the strongDM gateway/relay. | 9090 | &#9744; |
 | .configmap.SDM_DOCKERIZED | Setting this will automatically send logs to STDOUT overriding settings in AdminUI. | true | &#9744; |
 | .configmap.SDM_RELAY_LOG_FORMAT | Format for the logs when stored locally. | json | &#9744; |

--- a/deployments/sdm-relay/templates/Deployment.yaml
+++ b/deployments/sdm-relay/templates/Deployment.yaml
@@ -20,6 +20,7 @@ spec:
         image: {{ .Values.global.deployment.repository | default "quay.io/sdmrepo/relay" }}:{{ .Values.global.deployment.tag | default "latest" }}
         imagePullPolicy: {{ .Values.global.deployment.imagePullPolicy | default "Always" }}
         env:
+        {{- include "sdm.extraEnvironmentVars" .Values.global | indent 8 }}
         - name: SDM_RELAY_TOKEN
           valueFrom:
             secretKeyRef:

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -4,3 +4,16 @@ date: {{ now | htmlDate }}
 chart: {{ .Chart.Name }}
 version: {{ .Chart.Version }}
 {{- end }}
+
+{{/*
+Inject extra environment vars in the format key:value, if populated
+*/}}
+{{- define "sdm.extraEnvironmentVars" -}}
+{{- if .extraEnvironmentVars -}}
+{{- range $key, $value := .extraEnvironmentVars }}
+- name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+


### PR DESCRIPTION
Hi folks!

for some cases, it is useful to add Environment Variables to the Pod e.g. to allow the communication to Vault with self-signed certificates  (VAULT_SKIP_VERIFY: true)

How-to Use:
```
global:
  gateway:
    enabled: "true"
    service:
      type: LoadBalancer

  secret:
    token: token

  extraEnvironmentVars:
    VAULT_SKIP_VERIFY: "true"

configMap:
  SDM_RELAY_LOG_FORMAT: "json"
  SDM_ORCHESTRATOR_PROBES: 9090

```