### PR TITLE
feat: support loadBalancerIP config in relay gateway service

### DIFF
--- a/deployments/sdm-relay/templates/Service.yaml
+++ b/deployments/sdm-relay/templates/Service.yaml
@@ -8,6 +8,9 @@ metadata:
     app: {{ .Release.Name }}-app
 spec:
   type: {{ .Values.global.gateway.service.type | default "NodePort" }}
+  {{- if .Values.global.gateway.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.global.gateway.service.loadBalancerIP }}"
+  {{- end }}
   selector:
     app: {{ .Release.Name }}-app
   ports:

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -6,6 +6,7 @@ global:
       port: 30001
       #     External NodePort
       nodePort: 30001
+      # loadBalancerIP:
   secret:
     #   Use `echo -n token | base64` to base64 encode the Gateway/Relay token.
     token:


### PR DESCRIPTION
I saw your `CONTRIBUTING.md` says you're not taking contributions, and I'm hoping you consider this PR anyway or reproduce it yourselves in a way you're comfortable with.

I'd like to use this chart but without a `loadBalancerIP` configuration option, there's no way to use a `LoadBalancer` type service with a static IP (our preferred way to deploy), you're forced to use ephemeral each time.

The strategy used in this PR is analogous to the stable nginx-ingress helm chart which can be found here: https://github.com/helm/charts/blob/master/stable/nginx-ingress/templates/controller-service.yaml#L31-L33
