### PR TITLE
Fix nil pointer interface evaluation

### DIFF
--- a/deployments/sdm-relay/templates/Deployment.yaml
+++ b/deployments/sdm-relay/templates/Deployment.yaml
@@ -1,3 +1,4 @@
+{{- $globals := .Values.global -}}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -61,8 +62,8 @@ spec:
               name: {{ $.Release.Name }}-config
               key: SDM_RELAY_LOG_ENCRYPTION
         {{- end }}
+        {{- include "sdm.extraEnvironmentVars" $globals | indent 8 }}
         {{- if .SDM_ORCHESTRATOR_PROBES }}
-{{- include "sdm.extraEnvironmentVars" .Values.global | indent 8 }}
         livenessProbe:
           httpGet:
             path: /liveness


### PR DESCRIPTION
[This change](https://github.com/strongdm/charts/blob/280b9256ceb91eec6b831e91d2218c24239df54f/deployments/sdm-relay/templates/Deployment.yaml#L65) causes the error:
```
template: sdm-relay/templates/Deployment.yaml:65:46: executing "sdm-relay/templates/Deployment.yaml" at <.Values.global>: nil pointer evaluating interface {}.global
```

This occurs because the `.Values.global` is within the `with` block declared here:
https://github.com/strongdm/charts/blob/280b9256ceb91eec6b831e91d2218c24239df54f/deployments/sdm-relay/templates/Deployment.yaml#L28