### PR TITLE
[MAIN] Add annotation support for gateway/relay service

### DIFF
--- a/deployments/sdm-client/Chart.yaml
+++ b/deployments/sdm-client/Chart.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 appVersion: 1.0.0
 description: strongDM Client Container
 type: application
-icon: https://assets-global.website-files.com/5ecfe3add0194393eabdf182/5f5c071d917205912ebf7f0f_favicon32.png
+icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png
 home: https://github.com/strongdm/charts
 maintainers:
   - name: strongDM

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -5,7 +5,7 @@ version: 0.1.2
 appVersion: 1.0.0
 description: strongDM Relay
 type: application
-icon: https://assets-global.website-files.com/5ecfe3add0194393eabdf182/5f5c071d917205912ebf7f0f_favicon32.png
+icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png
 home: https://github.com/strongdm/charts
 maintainers:
   - name: strongDM

--- a/deployments/sdm-relay/templates/Service.yaml
+++ b/deployments/sdm-relay/templates/Service.yaml
@@ -3,6 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-svc
+  annotations: {{ toYaml (.Values.global.gateway.service.annotations) | nindent 4 }}
   labels:
 {{- include "sdm.labels" . | indent 4 }}
     app: {{ .Release.Name }}-app

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -7,6 +7,7 @@ global:
       #     External NodePort
       nodePort: 30001
       # loadBalancerIP:
+      annotations: {}
   secret:
     #   Use `echo -n token | base64` to base64 encode the Gateway/Relay token.
     token:


### PR DESCRIPTION
## Why?

- Often time we would want to add additional annotations in the service, for example to use AWS LB controller