### PR TITLE
feat: Support custom labels/annotation on relay deployment

### DIFF
--- a/deployments/sdm-relay/templates/Deployment.yaml
+++ b/deployments/sdm-relay/templates/Deployment.yaml
@@ -4,7 +4,14 @@ metadata:
   name: {{ .Release.Name }}-deployment
   labels:
     app: {{ .Release.Name }}-app
-{{- include "sdm.labels" . | indent 4 }}
+    {{- include "sdm.labels" . | indent 4 }}
+    {{- if .Values.global.deployment.labels }}
+{{ toYaml .Values.global.deployment.labels | indent 4 }}
+    {{- end }}
+  {{- if .Values.global.deployment.annotations }}
+  annotations:
+{{ toYaml .Values.global.deployment.annotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -14,6 +21,13 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-app
+        {{- if .Values.global.deployment.labels }}
+{{ toYaml .Values.global.deployment.labels | indent 8 }}
+        {{- end }}
+      {{- if .Values.global.deployment.annotations }}
+      annotations:
+{{ toYaml .Values.global.deployment.annotations | indent 8 }}
+      {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-app

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -15,6 +15,8 @@ global:
     repository: quay.io/sdmrepo/relay
     tag: latest
     imagePullPolicy: Always
+    annotations: {} # (Optional) adds additional annotations to the deployment and pod template
+    labels: {} # (Optional) adds additional labels to the deployment and pod template. These are not used as part of the selector
 
 # Optional Enviromental Values. Options can be found here(https://www.strongdm.com/docs/architecture/deployment/environment-variables).
 configMap:


### PR DESCRIPTION
This PR adds the optional ability to specify additional labels and annotations on the Deployment of the relay. 

We use this to configure monitoring tools like Datadog