### PR TITLE
fix: apply service account to spec

### DIFF
--- a/deployments/sdm-relay/templates/Deployment.yaml
+++ b/deployments/sdm-relay/templates/Deployment.yaml
@@ -29,6 +29,9 @@ spec:
 {{ toYaml .Values.global.deployment.annotations | indent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.serviceAccount }}
+      serviceAccountName: {{ $.Release.Name }}-svcacct
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-app
         image: {{ .Values.global.deployment.repository | default "quay.io/sdmrepo/relay" }}:{{ .Values.global.deployment.tag | default "latest" }}
@@ -86,7 +89,4 @@ spec:
           periodSeconds: 15
           failureThreshold: 5
         {{- end }}
-        {{- end }}
-        {{- with .Values.serviceAccount }}
-        serviceAccountName: {{ $.Release.Name }}-svcacct
         {{- end }}


### PR DESCRIPTION
The current structure applies the `serviceAccountName` to the container definition, but the reference documentation for the container definition doesn't seem to support a `serviceAccountName` field. Instead, it looks like this is supposed to be defined on the `spec` itself. This looks like it's causing my attempts to use this chart with a specific service account (rather than the `default` SA) to fail.