### PR TITLE
make date label optional, but default to true for consistency

### DIFF
--- a/deployments/sdm-client/Chart.yaml
+++ b/deployments/sdm-client/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-client
 kubeVersion: '>= 1.16.0-0'
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.0.0
 description: strongDM Client Container
 type: application

--- a/deployments/sdm-client/templates/_helpers.tpl
+++ b/deployments/sdm-client/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "sdm.labels" }}
 generator: helm
-{{- if (default true .Values.global.addDateLabel ) }}
+{{- if .Values.global.addDateLabel }}
 date: {{ now | htmlDate }}
 {{- end }}
 chart: {{ .Chart.Name }}

--- a/deployments/sdm-client/templates/_helpers.tpl
+++ b/deployments/sdm-client/templates/_helpers.tpl
@@ -1,6 +1,8 @@
 {{- define "sdm.labels" }}
 generator: helm
+{{- if (default true .Values.global.addDateLabel ) }}
 date: {{ now | htmlDate }}
+{{- end }}
 chart: {{ .Chart.Name }}
 version: {{ .Chart.Version }}
 {{- end }}

--- a/deployments/sdm-client/values.yaml
+++ b/deployments/sdm-client/values.yaml
@@ -1,4 +1,5 @@
 global:
+  addDateLabel: true # adds timestamp label to all resources
   service:
     type: ClusterIP
   secret:

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 0.1.10
+version: 0.1.11
 appVersion: 1.0.0
 description: StrongDM Proxy
 type: application

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -1,6 +1,8 @@
 {{- define "sdm.labels" }}
 generator: helm
+{{- if (default true .Values.addDateLabel ) }}
 date: {{ now | htmlDate }}
+{{- end }}
 chart: {{ .Chart.Name }}
 version: {{ .Chart.Version }}
 {{- end }}

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "sdm.labels" }}
 generator: helm
-{{- if (default true .Values.addDateLabel ) }}
+{{- if .Values.addDateLabel }}
 date: {{ now | htmlDate }}
 {{- end }}
 chart: {{ .Chart.Name }}

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -1,3 +1,5 @@
+addDateLabel: true # adds timestamp label to all resources
+
 # required. specify the name of a Secret containing the following environment variables:
 #  SDM_PROXY_CLUSTER_ACCESS_KEY: e.g. pk-4e172ba367007f0c
 #  SDM_PROXY_CLUSTER_SECRET_KEY: <...>

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 0.1.10
+version: 0.1.11
 appVersion: 1.0.0
 description: strongDM Relay
 type: application

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "sdm.labels" }}
 generator: helm
-{{- if (default true .Values.global.addDateLabel ) }}
+{{- if .Values.global.addDateLabel }}
 date: {{ now | htmlDate }}
 {{- end }}
 chart: {{ .Chart.Name }}

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -1,6 +1,8 @@
 {{- define "sdm.labels" }}
 generator: helm
+{{- if (default true .Values.global.addDateLabel ) }}
 date: {{ now | htmlDate }}
+{{- end }}
 chart: {{ .Chart.Name }}
 version: {{ .Chart.Version }}
 {{- end }}

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -1,4 +1,5 @@
 global:
+  addDateLabel: true # adds timestamp label to all resources
   gateway:
     enabled:
     service:


### PR DESCRIPTION
at the request of a customer, make this date label optional. default it to true to not change existing installations.

feels a bit hacky adding a very bespoke value, but couldn't think of another way to do this if we don't want to rip the label out altogether. customers may be relying on it.

open to suggestions on naming and/or placement of the value.