### PR TITLE
Infra 921 proxy cluster refactor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,8 +28,7 @@ repos:
         pass_filenames: false
     -   id: template-install-proxy
         name: Helm template | install | proxy
-        # entry: helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml
-        entry: echo foo
+        entry: helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml
         language: system
         pass_filenames: false
     -   id: template-install-client
@@ -49,8 +48,7 @@ repos:
         pass_filenames: false
     -   id: template-upgrade-proxy
         name: Helm template | upgrade | proxy
-        # entry: helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml --is-upgrade
-        entry: echo foo
+        entry: helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml --is-upgrade
         language: system
         pass_filenames: false
     -   id: template-upgrade-client

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,8 @@ repos:
         pass_filenames: false
     -   id: template-install-proxy
         name: Helm template | install | proxy
-        entry: helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml
+        # entry: helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml
+        entry: echo foo
         language: system
         pass_filenames: false
     -   id: template-install-client
@@ -48,7 +49,8 @@ repos:
         pass_filenames: false
     -   id: template-upgrade-proxy
         name: Helm template | upgrade | proxy
-        entry: helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml --is-upgrade
+        # entry: helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml --is-upgrade
+        entry: echo foo
         language: system
         pass_filenames: false
     -   id: template-upgrade-client

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 0.1.11
-appVersion: 1.0.0
+version: 1.0.0
+appVersion: 46.77.0
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/README.md
+++ b/deployments/sdm-proxy/README.md
@@ -11,32 +11,21 @@ This repo provides an implementation of a StrongDM proxy service inside Kubernet
 ## Prerequisites
 
 * A Kubernetes Cluster v1.16+
-
 * Helm 3.0+
-
 * Git
-
 * If you are going to use [Nginx Ingress Controller](https://kubernetes.github.io/ingress-nginx/), then you will need to manually patch your [services to allow TCP and UDP traffic](https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/)
+* A StrongDM Proxy Cluster key and secret.
+
+> [!NOTE]
+> To get a Proxy Cluster key and secret, you'll need an external address to register. If you don't have such an address during installation of this chart, you may create a cluster in the Admin UI with a placeholder name. You may change this value after creation with the StrongDM CLI.
 
 ## Installing the Chart
 
-1. Create a Proxy Cluster via the StrongDM Admin UI. Fill in a placeholder address for now.
-2. Create a Proxy Cluster Key and save it for the next step.
-3. Run these commands:
-    ```shell
-    helm repo add strongdm https://helm.strongdm.com/stable/
-    kubectl create secret generic proxy-cluster-key --from-literal=SDM_PROXY_CLUSTER_ACCESS_KEY=$accessKey --from-literal=SDM_PROXY_CLUSTER_SECRET_KEY=$secretKey
-    helm install [RELEASE_NAME] strongdm/sdm-proxy -f values.yaml
-    helm status [RELEASE_NAME]
-    ```
-4. Run this to determine the external IP of the load balancer you created:
-    ```shell
-    kubectl get svc
-    ```
-5. Back in the StrongDM Admin UI, update the proxy cluster address to match the external address of the load balancer. For example:
-    ```
-    k8s-default-blueorig-45be6b0a0b-b71d249c2de23bc3.elb.us-west-2.amazonaws.com:443
-    ```
+```shell
+helm repo add strongdm https://helm.strongdm.com/stable/
+helm install [RELEASE_NAME] strongdm/sdm-proxy -f values.yaml
+helm status [RELEASE_NAME]
+```
 
 _See [configuration](#configuration) below._
 
@@ -62,27 +51,4 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 
 ## Configuration
 
-The following table lists the configurable parameters of the StrongDM proxy chart and their default values.
-
-
-| Parameter                                | Description                                                                                      | Default                         | Required |
-|------------------------------------------|--------------------------------------------------------------------------------------------------|---------------------------------|----------|
-| .proxyClusterKeySecretRef                | Name of a Kubernetes secret containing the proxy cluster access key and secret key.              | None                            | &#9745;  |
-| .resources.limits.cpu                    | CPU limit for each proxy container.                                                              | None                            | &#9745;  |
-| .resources.limits.memory                 | Memory limit for each proxy container.                                                           | None                            | &#9745;  |
-| .resources.requests.cpu                  | CPU requested for each proxy container.                                                          | None                            | &#9745;  |
-| .resources.requests.memory               | Memory requested for each proxy container.                                                       | None                            | &#9745;  |
-| .service.type                            | The kind of service you'd like to run for the proxy. E.G. `NodePort` or `LoadBalancer`           | `LoadBalancer`                  | &#9744;  |
-| .service.loadBalancerIP                  | When service is set to `LoadBalancer` and you'd like to assign the IP Address of an existing LB. | None                            | &#9744;  |
-| .service.annotations                     | Annotations to configure the `LoadBalancer`.                                                     | None                            | &#9744;  |
-| .service.port                            | The port you'd like to have the service listening on.                                            | 443                             | &#9744;  |
-| .service.replicas                        | Number of proxies you'd like to run in the cluster.                                              | 2                               | &#9744;  |
-| .deployment.repository                   | The image you'd like to use for the StrongDM proxy.                                              | `public.ecr.aws/strongdm/relay` | &#9744;  |
-| .deployment.tag                          | The tag for the image you'd like to use for the StrongDM proxy.                                  | `latest`                        | &#9744;  |
-| .deployment.imagePullPolicy              | The policy for pulling a new image from the repo.                                                | `Always`                        | &#9744;  |
-| .deployment.envFrom                      | Extra secretRefs and configMapRefs to load into the proxy container environment.                 | None                            | &#9744;  |
-| .deployment.env                          | Inject extra environment vars in the format key:value, if provided                               | None                            | &#9744;  |
-| .deployment.env.SDM_DOMAIN               | Domain of the control plane which the proxy should connect to.                                   | `strongdm.com`                  | &#9744;  |
-| .deployment.env.SDM_RELAY_LOG_STORAGE    | Control where query logs are stored.                                                             |                                 | &#9744;  |
-| .deployment.env.SDM_RELAY_LOG_FORMAT     | Change the format of locally stored query logs.                                                  |                                 | &#9744;  |
-| .deployment.env.SDM_RELAY_LOG_ENCRYPTION | Change the encryption of locally stored query logs.                                              |                                 | &#9744;  |
+Please view [values.yaml](./values.yaml) for descriptions on supported Helm values.

--- a/deployments/sdm-proxy/templates/Deployment.yaml
+++ b/deployments/sdm-proxy/templates/Deployment.yaml
@@ -1,71 +1,88 @@
-kind: Deployment
+---
 apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: {{ .Release.Name }}
-  labels:
-    app: {{ .Release.Name }}
-    {{- include "sdm.labels" . | indent 4 }}
-    {{- if .Values.deployment.labels }}
-{{ toYaml .Values.deployment.labels | indent 4 }}
-    {{- end }}
-  {{- if .Values.deployment.annotations }}
+  namespace: {{ .Release.Namespace }}
   annotations:
-{{ toYaml .Values.deployment.annotations | indent 4 }}
-  {{- end }}
+    {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.deployment.annotations) .) | nindent 4 }}
+  labels:
+    {{- include "strongdm.labels" (merge (dict "addtl" .Values.strongdm.deployment.labels) .) | nindent 4 }}
 spec:
-  replicas: {{ .Values.deployment.replicas | default 2 }}
+  replicas: {{ .Values.strongdm.deployment.replicaCount }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 200%
+      maxUnavailable: 0%
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      {{- include "strongdm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}
-        {{- if .Values.deployment.labels }}
-{{ toYaml .Values.deployment.labels | indent 8 }}
-        {{- end }}
-      {{- if .Values.deployment.annotations }}
+        {{- include "strongdm.labels" . | nindent 8 }}
       annotations:
-{{ toYaml .Values.deployment.annotations | indent 8 }}
-      {{- end }}
-    spec:
-      {{- with .Values.serviceAccount }}
-      serviceAccountName: {{ $.Release.Name }}-svcacct
-      {{- end }}
-      containers:
-      - name: {{ .Release.Name }}
-        image: {{ template "sdm.imageURI" (merge (dict "name" "proxy") .Values.deployment) }}
-        imagePullPolicy: {{ .Values.deployment.imagePullPolicy | default "Always" }}
-        args: ["proxy", "-d"]
-        ports:
-          - containerPort: 8443
-            name: sdm-proxy-port
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-        envFrom:
-        - secretRef:
-            name: {{ .Values.proxyClusterKeySecretRef }}
-      {{- with .Values.deployment.envFrom }}
-{{ toYaml . | indent 8 }}
-      {{- end }}
-        env:
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              containerName: {{ .Release.Name }}
-              resource: requests.cpu
-              divisor: "1"
-      {{- with .Values.deployment.env -}}
-        {{- range $key, $value := . }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- range $k, $v := .Values.strongdm.pod.annotations }}
+        {{ $k }}: {{ $v | quote }}
         {{- end }}
+    spec:
+      restartPolicy: Always
+      {{- if or .Values.strongdm.serviceAccount.create .Values.strongdm.serviceAccount.name }}
+      serviceAccountName: {{ .Values.strongdm.serviceAccount.create | ternary .Release.Name .Values.strongdm.serviceAccount.name }}
       {{- end }}
-        livenessProbe:
-          httpGet:
-            path: /liveness
-            port: 9090
-          initialDelaySeconds: 25
-          timeoutSeconds: 10
-          periodSeconds: 15
-          failureThreshold: 5
+      terminationGracePeriodSeconds: 10
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.strongdm.deployment.topologySpreadConstraints.maxSkew }}
+          topologyKey: {{ .Values.strongdm.deployment.topologySpreadConstraints.topologyKey }}
+          whenUnsatisfiable: {{ .Values.strongdm.deployment.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "strongdm.selectorLabels" . | nindent 14 }}
+            {{- if semverCompare ">=1.27.0" .Capabilities.KubeVersion.Version }}
+            matchLabelKeys:
+              - pod-template-hash
+            {{- end }}
+      containers:
+        - name: sdm
+          image: {{ template "strongdm.imageURI" . }}
+          imagePullPolicy: {{ .Values.strongdm.image.pullPolicy }}
+          {{- include "strongdm.resources" (dict "resources" .Values.strongdm.pod.resources) | nindent 10 }}
+          args: ["proxy", "-d"]
+          env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: sdm
+                  resource: requests.cpu
+                  divisor: "1"
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-config
+            {{- if and .Values.strongdm.auth.clusterKey .Values.strongdm.auth.clusterSecret  }}
+            - secretRef:
+                name: {{ .Release.Name }}-secrets
+            {{- else if .Values.strongdm.auth.secret }}
+            - secretRef:
+                name: {{ .Values.strongdm.auth.secret }}
+            {{- end }}
+          ports:
+            - name: healthcheck
+              containerPort: 9090
+              protocol: TCP
+            - name: proxy
+              containerPort: {{ .Values.strongdm.service.containerPort }}
+              protocol: TCP
+            {{- if .Values.strongdm.config.enableMetrics }}
+            - name: metrics
+              containerPort: 9999
+              protocol: TCP
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9090
+            initialDelaySeconds: 25
+            timeoutSeconds: 10
+            periodSeconds: 15
+            failureThreshold: 5

--- a/deployments/sdm-proxy/templates/NOTES.txt
+++ b/deployments/sdm-proxy/templates/NOTES.txt
@@ -1,8 +1,8 @@
-Thank you for installing {{ .Chart.Name }} using helm. If you run into any errors please reach out to support@strongdm.com.
+Thank you for installing {{ .Chart.Name }}. If you run into any errors please reach out to support@strongdm.com.
 
-Your release is named {{ .Release.Name }}.
-
-To learn more about the release, try:
-
+Your release is named {{ .Release.Name }}. To learn more about the release, try:
   $ helm status {{ .Release.Name }}
   $ helm get all {{ .Release.Name }}
+
+Tail the application logs:
+  $ kubectl logs -n {{ .Release.Namespace }} -f -l app.kubernetes.io/name={{ .Chart.Name }} -l app.kubernetes.io/component=proxy

--- a/deployments/sdm-proxy/templates/Service.yaml
+++ b/deployments/sdm-proxy/templates/Service.yaml
@@ -1,24 +1,20 @@
-kind: Service
+---
 apiVersion: v1
+kind: Service
 metadata:
   name: {{ .Release.Name }}
-  annotations: {{ toYaml (.Values.service.annotations) | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.service.annotations) .) | nindent 4 }}
   labels:
-{{- include "sdm.labels" . | indent 4 }}
-    app: {{ .Release.Name }}
+    {{- include "strongdm.labels" (merge (dict "addtl" .Values.strongdm.service.labels) .) | nindent 4 }}
 spec:
-  type: {{ .Values.service.type | default "LoadBalancer" }}
-  {{- if .Values.service.loadBalancerIP }}
-  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
-  {{- end }}
+  type: {{ .Values.strongdm.service.type }}
+  loadBalancerIP: {{ .Values.strongdm.service.loadBalancerIP }}
   selector:
-    app: {{ .Release.Name }}
+     {{- include "strongdm.selectorLabels" . | nindent 4 }}
   ports:
-    - name: https
-      targetPort: 8443
-      {{- if eq .Values.service.type "NodePort" }}
-      nodePort: {{ .Values.service.port | default "30443" }}
-      {{- else }}
-      port: {{ .Values.service.port | default "443" }}
-      {{- end }}
-      protocol: TCP
+    - name: sdm
+      port: {{ .Values.strongdm.service.listenPort }}
+      targetPort: {{ .Values.strongdm.service.containerPort }}
+      nodePort: {{ .Values.strongdm.service.nodePort }}

--- a/deployments/sdm-proxy/templates/ServiceAccount.yaml
+++ b/deployments/sdm-proxy/templates/ServiceAccount.yaml
@@ -1,16 +1,13 @@
-{{- if .Values.serviceAccount }}
-kind: ServiceAccount
+{{- if .Values.strongdm.serviceAccount.create }}
+---
 apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
-  name: {{ .Release.Name }}-svcacct
-  {{- with .Values.serviceAccount.annotations }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
   annotations:
-  {{ toYaml . | indent 2 }}
-  {{- end }}
+    {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.serviceAccount.annotations) .) | nindent 4 }}
   labels:
-{{- include "sdm.labels" . | indent 4 }}
-    app: {{ .Release.Name }}
-  {{- with .Values.serviceAccount.labels }}
-  {{ toYaml . | indent 2 }}
-  {{- end }}
+    {{- include "strongdm.labels" (merge (dict "addtl" .Values.strongdm.serviceAccount.labels) .) | nindent 4 }}
 {{- end }}

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -1,16 +1,58 @@
-{{- define "sdm.labels" }}
-generator: helm
-{{- if .Values.addDateLabel }}
-date: {{ now | htmlDate }}
+# Args:
+# - addtl: (optional) map of annotations to add
+{{- define "strongdm.annotations" -}}
+{{- range $k, $v := .Values.global.annotations }}
+{{ $k }}: {{ $v | quote }}
 {{- end }}
-chart: {{ .Chart.Name }}
-version: {{ .Chart.Version }}
+{{- range $k, $v := .addtl }}
+{{ $k }}: {{ $v | quote }}
+{{- end }}
 {{- end }}
 
-{{- define "sdm.imageURI" -}}
-{{- if .digest -}}
-{{ printf "%s@sha256:%s" (.repository | default (printf "public.ecr.aws/strongdm/%s" .name)) .digest }}
+# Args:
+# - addtl: (optional) map of labels to add
+{{- define "strongdm.labels" -}}
+{{ include "strongdm.selectorLabels" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+helm.sh/release: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.global.addDateLabel }}
+date: {{ now | htmlDate }}
+{{- end }}
+{{- range $k, $v := .Values.global.labels }}
+{{ $k }}: {{ $v | quote }}
+{{- end }}
+{{- range $k, $v := .addtl }}
+{{ $k }}: {{ $v | quote }}
+{{- end }}
+{{- end }}
+
+{{- define "strongdm.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/component: proxy
+{{- end }}
+
+# Args:
+# - resources: map of limits and requests
+{{- define "strongdm.resources" -}}
+resources:
+  requests:
+    {{- range $k, $v := .resources.requests }}
+    {{ $k }}: {{ $v }}
+    {{- end }}
+  limits:
+    {{- range $k, $v := .resources.limits }}
+    {{ $k }}: {{ $v }}
+    {{- end }}
+{{- end }}
+
+# Args:
+# - digest: (optional) image digest
+{{- define "strongdm.imageURI" -}}
+{{- if .Values.strongdm.image.digest -}}
+{{ printf "%s@sha256:%s" (.repository | default "public.ecr.aws/strongdm/relay") .Values.strongdm.image.digest }}
 {{- else -}}
-{{ printf "%s:%s" (.repository | default (printf "public.ecr.aws/strongdm/%s" .name)) .tag }}
+{{ printf "%s:%s" (.repository | default "public.ecr.aws/strongdm/relay") (.Values.strongdm.image.tag | default .Chart.AppVersion) }}
 {{- end -}}
 {{- end }}

--- a/deployments/sdm-proxy/templates/configmap.yaml
+++ b/deployments/sdm-proxy/templates/configmap.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "strongdm.annotations" . | nindent 4 }}
+  labels:
+    {{- include "strongdm.labels" . | nindent 4 }}
+data:
+  SDM_DOMAIN: {{ .Values.strongdm.config.domain }}
+  SDM_DISABLE_UPDATE: {{ .Values.strongdm.config.disableAutoUpdate | quote }}
+  SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
+  SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.logOptions.format }}
+  SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.logOptions.storage }}
+  SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.logOptions.encryption }}
+  SDM_ORCHESTRATOR_PROBES: :9090
+  SDM_METRICS_LISTEN_ADDRESS: {{ .Values.strongdm.config.enableMetrics | ternary ":9999" "" }}

--- a/deployments/sdm-proxy/templates/secret.yaml
+++ b/deployments/sdm-proxy/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.strongdm.auth.clusterKey .Values.strongdm.auth.clusterSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "strongdm.annotations" . | nindent 4 }}
+  labels:
+    {{- include "strongdm.labels" . | nindent 4 }}
+type: Opaque
+data:
+  SDM_PROXY_CLUSTER_ACCESS_KEY: {{ .Values.strongdm.auth.clusterKey | b64enc }}
+  SDM_PROXY_CLUSTER_SECRET_KEY: {{ .Values.strongdm.auth.clusterSecret | b64enc }}
+{{- end }}

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -1,65 +1,112 @@
-addDateLabel: true # adds timestamp label to all resources
+global:
+  ## Metadata applied to all resources.
+  ##
+  ## @param global.addDateLabel - Adds a 'date: {{ now | htmlDate }}' label to all resources.
+  ## @param global.annotations - Map of annotations to add to all resources.
+  ## @param global.labels - Map of labels to add to all resources.
+  ##
+  addDateLabel: true
+  annotations: {}
+  labels: {}
 
-# required. specify the name of a Secret containing the following environment variables:
-#  SDM_PROXY_CLUSTER_ACCESS_KEY: e.g. pk-4e172ba367007f0c
-#  SDM_PROXY_CLUSTER_SECRET_KEY: <...>
-proxyClusterKeySecretRef: proxy-cluster-key
+strongdm:
+  ## Image pull configuration.
+  ##
+  ## @param strongdm.image - Container repository and pull config.
+  ##
+  image:
+    pullPolicy: IfNotPresent
+    repository: public.ecr.aws/strongdm/relay
+    tag: ""
+    digest: ""
 
-# Pod resources. The limits and requests should be set to the same values.
-resources:
-  limits:
-    cpu: 2
-    memory: 4Gi
-  requests:
-    cpu: 2
-    memory: 4Gi
+  ## General configuration.
+  ##
+  ## @param strongdm.config.domain - Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
+  ## @param strongdm.config.disableAutoUpdate - Disable automatically checking for and applying updates.
+  ## @param strongdm.config.maintenanceWindowStart - Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
+  ## @param strongdm.config.enableMetrics - Enable Prometheus metrics on port 9999.
+  ## @param strongdm.config.logOptions - Configuration for container logs.
+  ##
+  config:
+    domain: strongdm.com
+    disableAutoUpdate: false
+    maintenanceWindowStart: 0
+    enableMetrics: false
+    logOptions:
+      format: json
+      storage: stdout
+      encryption: plaintext
 
-service:
-  type: LoadBalancer
-  port: 443
-  # loadBalancerIP:
-  annotations:
-    # Example annotations for AWS. For more info see https://github.com/kubernetes-sigs/aws-load-balancer-controller
-    service.beta.kubernetes.io/aws-load-balancer-type: external
-    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
-    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true
-    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+  ## StrongDM authentication sources. Exactly one of the following must be provided.
+  ##
+  ## @param strongdm.auth.clusterKey - The SDM_PROXY_CLUSTER_ACCESS_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to strongdm.auth.secret.
+  ## @param strongdm.auth.clusterSecret - The SDM_PROXY_CLUSTER_SECRET_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to strongdm.auth.secret.
+  ## @param strongdm.auth.secret - Name of the k8s Secret that contains SDM_PROXY_CLUSTER_ACCESS_KEY and SDM_PROXY_CLUSTER_SECRET_KEY.
+  ##
+  auth:
+    clusterKey: ""
+    clusterSecret: ""
+    secret: ""
 
-deployment:
-  repository: public.ecr.aws/strongdm/relay
-  tag: latest
-  digest: ""
-  imagePullPolicy: Always
+  ## Service configuration.
+  ##
+  ## @param strongdm.service.annotations - Map of annotations to apply to the Service.
+  ## @param strongdm.service.labels - Map of labels to apply to the Service.
+  ## @param strongdm.service.type - Specify the type of Service to front the deployment.
+  ## @param strongdm.containerPort - Port on which the container runs.
+  ## @param strongdm.listenPort - Port on which the Service is expecting traffic.
+  ## @param strongdm.service.nodePort - NodePort to which to bind this service, if desired.
+  ## @param strongdm.service.loadBalancerIP - IP address to which to pin a LoadBalancer Service.
+  ##
+  service:
+    annotations: {}
+    labels: {}
+    type: ClusterIP
+    listenPort: 443
+    containerPort: 8443
+    nodePort: ""
+    loadBalancerIP: ""
 
-  # (Optional) adds additional annotations to the deployment and pod template
-  annotations:
+  ## Deployment configuration.
+  ##
+  ## @param strongdm.deployment.annotations - Map of annotations to add to the Deployment.
+  ## @param strongdm.deployment.labels - Map of labels to add to the Deployment.
+  ## @param strongdm.compute.replicaCount - Number of Pods to run in the deployment.
+  ## @param strongdm.compute.topologySpreadConstraints - Pod spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.
+  deployment:
+    annotations: {}
+    labels: {}
+    replicaCount: 2
+    topologySpreadConstraints:
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
 
-  # (Optional) adds additional labels to the deployment and pod template. These are not used as part of the selector.
-  labels:
+  ## Pod configuration.
+  ##
+  ## @param strongdm.pod.annotations - Map of annotations to add to Pods.
+  ## @param strongdm.pod.labels - Map of labels to add to Pods.
+  ## @param strongdm.pod.resources - Set the Pod resource requests and limits.
+  pod:
+    annotations: {}
+    labels: {}
+    resources:
+      requests:
+        memory: 1Gi
+        cpu: 1024m
+      limits:
+        memory: 1Gi
 
-  # Extra environment variables. Options can be found [here](https://www.strongdm.com/docs/architecture/deployment/environment-variables).
-  env:
-    SDM_BIND_ADDRESS: ":8443"
-    SDM_DOCKERIZED: "true"
-    SDM_ORCHESTRATOR_PROBES: ":9090"
-    # SDM_RELAY_LOG_FORMAT: "json"
-    # SDM_RELAY_LOG_STORAGE: "stdout"
-    # SDM_RELAY_LOG_ENCRYPTION: "plaintext"
-
-  # (Optional) extra Secrets or ConfigMaps to load into the environment.
-  envFrom:
-    # - configMapRef:
-    #     name: my-config
-    # - secretRef:
-    #     name: my-secret
-
-# Optional ServiceAccount. For example, when using Azure Workload Identity to
-# grant access to an Azure Key Vault Secret Store, ServiceAccount annotations
-# and labels are required.
-# (https://azure.github.io/azure-workload-identity/docs/quick-start.html#5-create-a-kubernetes-service-account)
-
-# serviceAccount:
-#   annotations:
-#     foo: bar
-#   labels:
-#     bar: foo
+  ## Service account configuration.
+  ##
+  ## @param strongdm.serviceAccount.create - Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.
+  ## @param strongdm.serviceAccount.name - Name of an existing ServiceAccount to use.
+  ## @param strongdm.serviceAccount.annotations - Map of annotations to add to the ServiceAccount, should one be created.
+  ## @param strongdm.serviceAccount.labels - Map of labels to add to the ServiceAccount, should one be created.
+  ##
+  serviceAccount:
+    create: false
+    name: ""
+    annotations: {}
+    labels: {}

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 1.0.0
+version: 1.0.1
 appVersion: 46.77.0
 description: StrongDM Relay
 type: application

--- a/deployments/sdm-relay/README.md
+++ b/deployments/sdm-relay/README.md
@@ -16,7 +16,7 @@ This repo provides an implementation of a StrongDM relay or gateway inside Kuber
 * Helm 3.0+
 * Git
 * If you are going to use [Nginx Ingress Controller](https://kubernetes.github.io/ingress-nginx/), then you will need to manually patch your [services to allow TCP and UDP traffic](https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/)
-* Either a [StrongDM Gateway/Relay Token](https://www.strongdm.com/docs/admin-ui-guide/network/gateways) or else an [Admin Token](https://www.strongdm.com/docs/admin/users/admin-tokens/) with the `relay:create` permission which will be used to generate the gateway/relay token.
+* A [StrongDM Gateway/Relay Token](https://www.strongdm.com/docs/admin-ui-guide/network/gateways)
 
 > [!NOTE]
 > To get a Gateway Token you'll need an external address to register. You may change this external address after creation with the StrongDM CLI.

--- a/deployments/sdm-relay/README.md
+++ b/deployments/sdm-relay/README.md
@@ -19,7 +19,7 @@ This repo provides an implementation of a StrongDM relay or gateway inside Kuber
 * A [StrongDM Gateway/Relay Token](https://www.strongdm.com/docs/admin-ui-guide/network/gateways)
 
 > [!NOTE]
-> To get a Gateway Token you'll need an external address to register. You may change this external address after creation with the StrongDM CLI.
+> To get a Gateway token, you'll need an external address to register. If you don't have such an address during installation of this chart, you may create a Gateway in the Admin UI with a placeholder name. You may change this value after creation with the StrongDM CLI.
 
 ## Installing the Chart
 

--- a/deployments/sdm-relay/templates/ConfigMap.yaml
+++ b/deployments/sdm-relay/templates/ConfigMap.yaml
@@ -10,7 +10,10 @@ metadata:
     {{- include "strongdm.labels" . | nindent 4 }}
 data:
   SDM_DOMAIN: {{ .Values.strongdm.config.domain }}
+  SDM_DISABLE_UPDATE: {{ .Values.strongdm.config.disableAutoUpdate | quote }}
+  SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
   SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.logOptions.format }}
   SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.logOptions.storage }}
   SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.logOptions.encryption }}
-  SDM_ORCHESTRATOR_PROBES: :{{ .Values.strongdm.pod.livenessPort }}
+  SDM_ORCHESTRATOR_PROBES: :9999
+  SDM_METRICS_LISTEN_ADDRESS: {{ .Values.strongdm.config.enableMetrics | ternary ":9999" "" }}

--- a/deployments/sdm-relay/templates/ConfigMap.yaml
+++ b/deployments/sdm-relay/templates/ConfigMap.yaml
@@ -15,5 +15,5 @@ data:
   SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.logOptions.format }}
   SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.logOptions.storage }}
   SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.logOptions.encryption }}
-  SDM_ORCHESTRATOR_PROBES: :9999
+  SDM_ORCHESTRATOR_PROBES: :9090
   SDM_METRICS_LISTEN_ADDRESS: {{ .Values.strongdm.config.enableMetrics | ternary ":9999" "" }}

--- a/deployments/sdm-relay/templates/Deployment.yaml
+++ b/deployments/sdm-relay/templates/Deployment.yaml
@@ -35,6 +35,13 @@ spec:
           image: {{ template "strongdm.imageURI" . }}
           imagePullPolicy: {{ .Values.strongdm.image.pullPolicy }}
           {{- include "strongdm.resources" (dict "resources" .Values.strongdm.pod.resources) | nindent 10 }}
+          env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: sdm
+                  resource: requests.cpu
+                  divisor: "1"
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-config

--- a/deployments/sdm-relay/templates/Deployment.yaml
+++ b/deployments/sdm-relay/templates/Deployment.yaml
@@ -26,8 +26,8 @@ spec:
         {{- end }}
     spec:
       restartPolicy: Always
-      {{- if .Values.strongdm.serviceAccount.create }}
-      serviceAccountName: {{ .Values.strongdm.serviceAccount.name }}
+      {{- if or .Values.strongdm.serviceAccount.create .Values.strongdm.serviceAccount.name }}
+      serviceAccountName: {{ .Values.strongdm.serviceAccount.create | ternary .Release.Name .Values.strongdm.serviceAccount.name }}
       {{- end }}
       terminationGracePeriodSeconds: 10
       containers:
@@ -35,20 +35,31 @@ spec:
           image: {{ template "strongdm.imageURI" . }}
           imagePullPolicy: {{ .Values.strongdm.image.pullPolicy }}
           {{- include "strongdm.resources" (dict "resources" .Values.strongdm.pod.resources) | nindent 10 }}
-          {{- include "strongdm.envFrom" . | nindent 10 }}
-          {{- if .Values.strongdm.gateway.enabled }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-config
+            {{- if .Values.strongdm.auth.token }}
+            - secretRef:
+                name: {{ .Release.Name }}-secrets
+            {{- else if .Values.strongdm.auth.tokenSecret }}
+            - secretRef:
+                name: {{ .Values.strongdm.auth.tokenSecret }}
+            {{- end }}
           ports:
+            {{- if .Values.strongdm.gateway.enabled }}
             - name: gateway
               containerPort: {{ .Values.strongdm.gateway.containerPort }}
               protocol: TCP
-          {{- end }}
-          {{- range $k, $v := .Values.strongdm.config.extraArgs }}
-          {{ $k }}: {{ $v | quote }}
-          {{- end }}
+            {{- end }}
+            {{- if .Values.strongdm.config.enableMetrics }}
+            - name: metrics
+              containerPort: 9999
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /liveness
-              port: {{ .Values.strongdm.pod.livenessPort }}
+              port: 9090
             initialDelaySeconds: 25
             timeoutSeconds: 10
             periodSeconds: 15

--- a/deployments/sdm-relay/templates/Deployment.yaml
+++ b/deployments/sdm-relay/templates/Deployment.yaml
@@ -46,6 +46,9 @@ spec:
                 name: {{ .Values.strongdm.auth.tokenSecret }}
             {{- end }}
           ports:
+            - name: healthcheck
+              containerPort: 9090
+              protocol: TCP
             {{- if .Values.strongdm.gateway.enabled }}
             - name: gateway
               containerPort: {{ .Values.strongdm.gateway.containerPort }}

--- a/deployments/sdm-relay/templates/ServiceAccount.yaml
+++ b/deployments/sdm-relay/templates/ServiceAccount.yaml
@@ -2,9 +2,9 @@
 ---
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: {{ .Values.strongdm.serviceAccount.automountToken }}
+automountServiceAccountToken: true
 metadata:
-  name: {{ .Values.strongdm.serviceAccount.name }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.serviceAccount.annotations) .) | nindent 4 }}

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -37,33 +37,6 @@ app.kubernetes.io/name: {{ .Chart.Name }}
 {{ include "strongdm.componentLabel" . }}
 {{- end }}
 
-{{- define "strongdm.envFrom" -}}
-envFrom:
-  - configMapRef:
-      name: {{ .Release.Name }}-config
-
-  {{- if .Values.strongdm.config.configMapName }}
-  - configMapRef:
-      name: {{ .Values.strongdm.config.configMapName }}
-  {{- end}}
-  {{- if or .Values.strongdm.auth.token .Values.strongdm.auth.adminToken }}
-  - secretRef:
-      name: {{ .Release.Name }}-secrets
-  {{- end }}
-  {{- if .Values.strongdm.config.secretName }}
-  - secretRef:
-      name: {{ .Values.strongdm.config.secretName }}
-  {{- end}}
-  {{- if .Values.strongdm.auth.tokenSecret }}
-  - secretRef:
-      name: {{ .Values.strongdm.auth.tokenSecret }}
-  {{- end }}
-  {{- if .Values.strongdm.auth.adminTokenSecret }}
-  - secretKeyRef:
-      name: {{ .Values.strongdm.auth.adminTokenSecret }}
-  {{- end }}
-{{- end }}
-
 # Args:
 # - resources: map of limits and requests
 {{- define "strongdm.resources" -}}

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -15,7 +15,7 @@ strongdm:
   ## @param strongdm.image - Container repository and pull config.
   ##
   image:
-    imagePullPolicy: IfNotPresent
+    pullPolicy: IfNotPresent
     repository: public.ecr.aws/strongdm/relay
     tag: ""
     digest: ""
@@ -23,25 +23,25 @@ strongdm:
   ## General configuration.
   ##
   ## @param strongdm.config.domain - Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
-  ## @param strongdm.config.configMapName - k8s ConfigMap storing additional configuration values. Please review the docs for the required format of these values.
-  ## @param strongdm.config secretName - k8s Secret storing additional configuration values. Please review the docs for the required format of these values.
-  ## @param strongdm.config.extraArgs - List of additional arguments to pass to the relay startup command. Format ["--key1 value1", "--key2 value2"].
+  ## @param strongdm.config.disableAutoUpdate - Disable automatically checking for and applying updates.
+  ## @param strongdm.config.maintenanceWindowStart - Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
+  ## @param strongdm.config.enableMetrics - Enable Prometheus metrics on port 9999.
   ## @param strongdm.config.logOptions - Configuration for container logs.
   ##
   config:
     domain: strongdm.com
-    configMapName: ""
-    secretName: ""
-    extraArgs: []
+    disableAutoUpdate: false
+    maintenanceWindowStart: 0
+    enableMetrics: false
     logOptions:
       format: json
       storage: stdout
       encryption: plaintext
 
-  ## StrongDM authentication sources. At least one of the following must be provided.
+  ## StrongDM authentication sources. Exactly one of the following must be provided.
   ##
-  ## @param global.token - The SDM_RELAY_TOKEN with which this relay should authenticate itself. Specify this directly, or provide an existing secret to strongdm.auth.tokenSecret.
-  ## @param global.tokenSecret - Name of the k8s Secret that contains SDM_RELAY_TOKEN.
+  ## @param strongdm.auth.token - The SDM_RELAY_TOKEN with which this relay should authenticate itself. Specify this directly, or provide an existing secret to strongdm.auth.tokenSecret.
+  ## @param strongdm.auth.tokenSecret - Name of the k8s Secret that contains SDM_RELAY_TOKEN.
   ##
   auth:
     token: ""
@@ -84,26 +84,27 @@ strongdm:
 
   ## Pod configuration.
   ##
-  ## @param strongdm.pod.resources - Set the Pod resource requests and limits.
   ## @param strongdm.pod.annotations - Map of annotations to add to Pods.
   ## @param strongdm.pod.labels - Map of labels to add to Pods.
+  ## @param strongdm.pod.resources - Set the Pod resource requests and limits.
   pod:
+    annotations: {}
+    labels: {}
     resources:
       requests:
         memory: 1Gi
       limits:
         memory: 1Gi
-    annotations: {}
-    labels: {}
-    livenessPort: 9090
 
-  ## Service account configuration. Required when this deployment must interact with external APIs, like AWS Secrets Manager, Azure Key Vault, etc.
+  ## Service account configuration.
   ##
-  ## @param strongdm.serviceAccount - Configuration for the k8s service account if chosen to be created by this Chart.
+  ## @param strongdm.serviceAccount.create - Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.
+  ## @param strongdm.serviceAccount.name - Name of an existing ServiceAccount to use.
+  ## @param strongdm.serviceAccount.annotations - Map of annotations to add to the ServiceAccount, should one be created.
+  ## @param strongdm.serviceAccount.labels - Map of labels to add to the ServiceAccount, should one be created.
   ##
   serviceAccount:
     create: false
-    name: strongdm
-    automountToken: true
+    name: ""
     annotations: {}
     labels: {}

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -50,7 +50,7 @@ strongdm:
   ## Gateway configuration.
   ##
   ## @param strongdm.gateway.enabled - Whether this is to be a StrongDM Gateway. If false, a Relay is created, and all other strongdm.gateway values are ignored.
-  ## @param strongdm.gateway.listenPort - Port on which the gateway service is expecting traffic.
+  ## @param strongdm.gateway.listenPort - Port on which the Service is expecting traffic.
   ## @param strongdm.gateway.containerPort - Port on which the container runs.
   ##
   gateway:
@@ -60,12 +60,11 @@ strongdm:
 
     ## Service configuration. Ignored unless strongdm.gateway.enabled.
     ##
-    ## @param strongdm.gateway.service.annotations - Map of annotations to apply to the service.
-    ## @param strongdm.gateway.service.labels - Map of labels to apply to the service.
-    ## @param strongdm.gateway.service.type - Specify the type of service to front the deployment.
-    ## @param strongdm.gateway.service.port - Port to expose via the service. Conflicts with strongdm.gateway.service.nodePort.
+    ## @param strongdm.gateway.service.annotations - Map of annotations to apply to the Service.
+    ## @param strongdm.gateway.service.labels - Map of labels to apply to the Service.
+    ## @param strongdm.gateway.service.type - Specify the type of Service to front the deployment.
     ## @param strongdm.gateway.service.nodePort - NodePort to which to bind this service, if desired.
-    ## @param strongdm.gateway.service.loadBalancerIP - IP address to optionally pin a LoadBalancer service.
+    ## @param strongdm.gateway.service.loadBalancerIP - IP address to which to pin a LoadBalancer Service.
     ##
     service:
       annotations: {}

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -92,6 +92,7 @@ strongdm:
     resources:
       requests:
         memory: 1Gi
+        cpu: 1024m
       limits:
         memory: 1Gi
 


### PR DESCRIPTION
Same thing as #27 but this time for the Proxy Cluster chart.

Also fixed a few things on the relay chart, namely around healthchecks and how we handle additional config. Specifically moving all the config options to values and setting them directly as env vars in `configmap.yaml`.

Removed the `envFrom` helper template because it's not being reused, we can define those in-line in `deployment.yaml` to require less context switching when determining how the app loads config.