### PR TITLE
Chim 899 auto register pod identity cluster

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,21 +14,30 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 
+-   repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.26
+    hooks:
+    -   id: helmlint
+    -   id: shellcheck
+
 -   repo: local
     hooks:
     -   id: template-install-relay
         name: Helm template | install | relay
         entry: helm template deployments/sdm-relay -f deployments/sdm-relay/values.yaml
+          -f deployments/sdm-relay/values.test.yaml
         language: system
         pass_filenames: false
     -   id: template-install-gateway
         name: Helm template | install | gateway
-        entry: helm template deployments/sdm-relay -f deployments/sdm-relay/values.yaml --set strongdm.gateway.enabled=true
+        entry: helm template deployments/sdm-relay -f deployments/sdm-relay/values.yaml
+          -f deployments/sdm-relay/values.test.yaml --set strongdm.gateway.enabled=true
         language: system
         pass_filenames: false
     -   id: template-install-proxy
         name: Helm template | install | proxy
         entry: helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml
+          -f deployments/sdm-proxy/values.test.yaml
         language: system
         pass_filenames: false
     -   id: template-install-client
@@ -38,27 +47,38 @@ repos:
         pass_filenames: false
     -   id: template-upgrade-relay
         name: Helm template | upgrade | relay
-        entry: helm template deployments/sdm-relay -f deployments/sdm-relay/values.yaml --is-upgrade
+        entry: helm template deployments/sdm-relay -f deployments/sdm-relay/values.yaml
+          -f deployments/sdm-relay/values.test.yaml --is-upgrade
         language: system
         pass_filenames: false
     -   id: template-upgrade-gateway
         name: Helm template | upgrade | gateway
-        entry: helm template deployments/sdm-relay -f deployments/sdm-relay/values.yaml --is-upgrade --set strongdm.gateway.enabled=true
+        entry: helm template deployments/sdm-relay -f deployments/sdm-relay/values.yaml
+          -f deployments/sdm-relay/values.test.yaml --is-upgrade --set strongdm.gateway.enabled=true
         language: system
         pass_filenames: false
     -   id: template-upgrade-proxy
         name: Helm template | upgrade | proxy
-        entry: helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml --is-upgrade
+        entry: helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml
+          --is-upgrade -f deployments/sdm-proxy/values.test.yaml
         language: system
         pass_filenames: false
     -   id: template-upgrade-client
         name: Helm template | upgrade | client
-        entry: helm template deployments/sdm-client -f deployments/sdm-client/values.yaml --is-upgrade
+        entry: helm template deployments/sdm-client -f deployments/sdm-client/values.yaml
+          --is-upgrade
         language: system
         pass_filenames: false
 
--   repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.26
+-   repo: https://github.com/losisin/helm-values-schema-json
+    rev: v1.8.0
     hooks:
-    -   id: helmlint
-    -   id: shellcheck
+    -   id: helm-schema
+        name: helm-schema | relay
+        args: ["-input", "deployments/sdm-relay/values.yaml", "-output", "deployments/sdm-relay/values.schema.json"]
+    -   id: helm-schema
+        name: helm-schema | proxy
+        args: ["-input", "deployments/sdm-proxy/values.yaml", "-output", "deployments/sdm-proxy/values.schema.json"]
+    -   id: helm-schema
+        name: helm-schema | client
+        args: ["-input", "deployments/sdm-client/values.yaml", "-output", "deployments/sdm-client/values.schema.json"]

--- a/deployments/sdm-client/values.schema.json
+++ b/deployments/sdm-client/values.schema.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "configMap": {
+            "properties": {
+                "SDM_DOCKERIZED": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "global": {
+            "properties": {
+                "addDateLabel": {
+                    "type": "boolean"
+                },
+                "deployment": {
+                    "properties": {
+                        "digest": {
+                            "type": "string"
+                        },
+                        "imagePullPolicy": {
+                            "type": "string"
+                        },
+                        "ports": {
+                            "items": {
+                                "type": "integer"
+                            },
+                            "type": "array"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "secret": {
+                    "properties": {
+                        "token": {
+                            "type": "null"
+                        }
+                    },
+                    "type": "object"
+                },
+                "service": {
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "type": "object"
+}

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 1.0.0
+version: 1.0.1
 appVersion: 46.77.0
 description: StrongDM Proxy
 type: application

--- a/deployments/sdm-proxy/templates/Deployment.yaml
+++ b/deployments/sdm-proxy/templates/Deployment.yaml
@@ -19,13 +19,11 @@ spec:
       {{- include "strongdm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      labels:
-        {{- include "strongdm.labels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- range $k, $v := .Values.strongdm.pod.annotations }}
-        {{ $k }}: {{ $v | quote }}
-        {{- end }}
+        {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.pod.annotations) .) | nindent 8 }}
+      labels:
+        {{- include "strongdm.labels" (merge (dict "addtl" .Values.strongdm.pod.labels) .) | nindent 8 }}
     spec:
       restartPolicy: Always
       {{- if or .Values.strongdm.serviceAccount.create .Values.strongdm.serviceAccount.name }}
@@ -56,16 +54,19 @@ spec:
                   containerName: sdm
                   resource: requests.cpu
                   divisor: "1"
+            - name: SDM_PROXY_CLUSTER_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.strongdm.auth.authSecretName | default (printf "%s-secrets" .Release.Name) }}
+                  key: SDM_PROXY_CLUSTER_ACCESS_KEY
+            - name: SDM_PROXY_CLUSTER_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.strongdm.auth.authSecretName | default (printf "%s-secrets" .Release.Name) }}
+                  key: SDM_PROXY_CLUSTER_SECRET_KEY
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-config
-            {{- if and .Values.strongdm.auth.clusterKey .Values.strongdm.auth.clusterSecret  }}
-            - secretRef:
-                name: {{ .Release.Name }}-secrets
-            {{- else if .Values.strongdm.auth.secret }}
-            - secretRef:
-                name: {{ .Values.strongdm.auth.secret }}
-            {{- end }}
           ports:
             - name: healthcheck
               containerPort: 9090

--- a/deployments/sdm-proxy/templates/Deployment.yaml
+++ b/deployments/sdm-proxy/templates/Deployment.yaml
@@ -57,12 +57,12 @@ spec:
             - name: SDM_PROXY_CLUSTER_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.strongdm.auth.authSecretName | default (printf "%s-secrets" .Release.Name) }}
+                  name: {{ .Values.strongdm.auth.secretName | default (printf "%s-secrets" .Release.Name) }}
                   key: SDM_PROXY_CLUSTER_ACCESS_KEY
             - name: SDM_PROXY_CLUSTER_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.strongdm.auth.authSecretName | default (printf "%s-secrets" .Release.Name) }}
+                  name: {{ .Values.strongdm.auth.secretName | default (printf "%s-secrets" .Release.Name) }}
                   key: SDM_PROXY_CLUSTER_SECRET_KEY
           envFrom:
             - configMapRef:

--- a/deployments/sdm-proxy/templates/post-install.yaml
+++ b/deployments/sdm-proxy/templates/post-install.yaml
@@ -37,7 +37,7 @@ spec:
             - name: SDM_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.strongdm.auth.authSecretName | default (printf "%s-secrets" .Release.Name) }}
+                  name: {{ .Values.strongdm.auth.secretName | default (printf "%s-secrets" .Release.Name) }}
                   key: SDM_ADMIN_TOKEN
           envFrom:
             - configMapRef:

--- a/deployments/sdm-proxy/templates/post-install.yaml
+++ b/deployments/sdm-proxy/templates/post-install.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.strongdm.autoRegisterCluster.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-register-cluster
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-1"
+    {{- include "strongdm.annotations" . | nindent 4 }}
+  labels:
+    {{- include "strongdm.labels" . | nindent 4 }}
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      annotations:
+        {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.pod.annotations) .) | nindent 8 }}
+      labels:
+        {{- include "strongdm.labels" (merge (dict "addtl" .Values.strongdm.pod.labels) .) | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: sdm
+          image: {{ template "strongdm.imageURI" . }}
+          imagePullPolicy: {{ .Values.strongdm.image.pullPolicy }}
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 256m
+            limits:
+              memory: 256Mi
+          env:
+            - name: SDM_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.strongdm.auth.authSecretName | default (printf "%s-secrets" .Release.Name) }}
+                  key: SDM_ADMIN_TOKEN
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-config
+          command:
+            - /bin/bash
+            - -c
+            - |
+              /sdm.linux login --admin-token="${SDM_ADMIN_TOKEN}"
+              /sdm.linux admin clusters add k8spodidentity --certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt {{ .Values.strongdm.autoRegisterCluster.extraArgs }} {{ .Values.strongdm.autoRegisterCluster.resourceName | default (printf "%s-cluster-%s" .Release.Name (randAlpha 5)) }}
+{{- end}}

--- a/deployments/sdm-proxy/templates/secret.yaml
+++ b/deployments/sdm-proxy/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.strongdm.auth.authSecretName }}
+{{- if not .Values.strongdm.auth.secretName }}
 ---
 apiVersion: v1
 kind: Secret

--- a/deployments/sdm-proxy/templates/secret.yaml
+++ b/deployments/sdm-proxy/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.strongdm.auth.clusterKey .Values.strongdm.auth.clusterSecret }}
+{{- if not .Values.strongdm.auth.authSecretName }}
 ---
 apiVersion: v1
 kind: Secret
@@ -13,4 +13,5 @@ type: Opaque
 data:
   SDM_PROXY_CLUSTER_ACCESS_KEY: {{ .Values.strongdm.auth.clusterKey | b64enc }}
   SDM_PROXY_CLUSTER_SECRET_KEY: {{ .Values.strongdm.auth.clusterSecret | b64enc }}
+  SDM_ADMIN_TOKEN: {{ .Values.strongdm.auth.adminToken | b64enc }}
 {{- end }}

--- a/deployments/sdm-proxy/values.schema.json
+++ b/deployments/sdm-proxy/values.schema.json
@@ -1,0 +1,223 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "global": {
+            "properties": {
+                "addDateLabel": {
+                    "type": "boolean"
+                },
+                "annotations": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "labels": {
+                    "properties": {},
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "strongdm": {
+            "properties": {
+                "auth": {
+                    "properties": {
+                        "adminToken": {
+                            "type": "string"
+                        },
+                        "authSecretName": {
+                            "type": "string"
+                        },
+                        "clusterKey": {
+                            "type": "string"
+                        },
+                        "clusterSecret": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "autoRegisterCluster": {
+                    "properties": {
+                        "adminToken": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "extraArgs": {
+                            "type": "string"
+                        },
+                        "resourceName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "config": {
+                    "properties": {
+                        "disableAutoUpdate": {
+                            "type": "boolean"
+                        },
+                        "domain": {
+                            "type": "string"
+                        },
+                        "enableMetrics": {
+                            "type": "boolean"
+                        },
+                        "logOptions": {
+                            "properties": {
+                                "encryption": {
+                                    "type": "string"
+                                },
+                                "format": {
+                                    "type": "string"
+                                },
+                                "storage": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "maintenanceWindowStart": {
+                            "type": "integer"
+                        }
+                    },
+                    "type": "object"
+                },
+                "deployment": {
+                    "properties": {
+                        "annotations": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "labels": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "replicaCount": {
+                            "type": "integer"
+                        },
+                        "topologySpreadConstraints": {
+                            "properties": {
+                                "maxSkew": {
+                                    "type": "integer"
+                                },
+                                "topologyKey": {
+                                    "type": "string"
+                                },
+                                "whenUnsatisfiable": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "image": {
+                    "properties": {
+                        "digest": {
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "pod": {
+                    "properties": {
+                        "annotations": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "labels": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "resources": {
+                            "properties": {
+                                "limits": {
+                                    "properties": {
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "requests": {
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "string"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "service": {
+                    "properties": {
+                        "annotations": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "labels": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "listenPort": {
+                            "type": "integer"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string"
+                        },
+                        "nodePort": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "serviceAccount": {
+                    "properties": {
+                        "annotations": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "labels": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "type": "object"
+}

--- a/deployments/sdm-proxy/values.schema.json
+++ b/deployments/sdm-proxy/values.schema.json
@@ -24,13 +24,13 @@
                         "adminToken": {
                             "type": "string"
                         },
-                        "authSecretName": {
-                            "type": "string"
-                        },
                         "clusterKey": {
                             "type": "string"
                         },
                         "clusterSecret": {
+                            "type": "string"
+                        },
+                        "secretName": {
                             "type": "string"
                         }
                     },
@@ -38,9 +38,6 @@
                 },
                 "autoRegisterCluster": {
                     "properties": {
-                        "adminToken": {
-                            "type": "string"
-                        },
                         "enabled": {
                             "type": "boolean"
                         },

--- a/deployments/sdm-proxy/values.test.yaml
+++ b/deployments/sdm-proxy/values.test.yaml
@@ -1,0 +1,9 @@
+## Test file to be merged with values.yaml.
+##
+## Set all "create" flags to true to exhaust as many config options as possible.
+##
+strongdm:
+  serviceAccount:
+    create: true
+  autoRegisterCluster:
+    enabled: true

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -38,16 +38,29 @@ strongdm:
       storage: stdout
       encryption: plaintext
 
-  ## StrongDM authentication sources. Exactly one of the following must be provided.
+  ## Auto registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the support @strongdm.auth methods.
   ##
-  ## @param strongdm.auth.clusterKey - The SDM_PROXY_CLUSTER_ACCESS_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to strongdm.auth.secret.
-  ## @param strongdm.auth.clusterSecret - The SDM_PROXY_CLUSTER_SECRET_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to strongdm.auth.secret.
-  ## @param strongdm.auth.secret - Name of the k8s Secret that contains SDM_PROXY_CLUSTER_ACCESS_KEY and SDM_PROXY_CLUSTER_SECRET_KEY.
+  ## @param strongdm.config.autoRegisterCluster.enabled - Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
+  ## @param strongdm.config.autoRegisterCluster.resourceName - Name of the StrongDM Pod Identity Cluster resource to create.
+  ## @param strongdm.config.autoRegisterCluster.extraArgs - Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.
   ##
+  autoRegisterCluster:
+    enabled: false
+    resourceName: ""
+    extraArgs: ""
+    adminToken: ""
+
+  ## StrongDM authentication sources.
+  ##
+  ## @param strongdm.auth.clusterKey - The SDM_PROXY_CLUSTER_ACCESS_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.authSecretName.
+  ## @param strongdm.auth.clusterSecret - The SDM_PROXY_CLUSTER_SECRET_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.authSecretName.
+  ## @param strongdm.auth.adminToken - The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.authSecretName.
+  ## @param strongdm.auth.authSecretName - Name of the k8s Secret that contains SDM_PROXY_CLUSTER_ACCESS_KEY and SDM_PROXY_CLUSTER_SECRET_KEY, and/or SDM_ADMIN_TOKEN.
   auth:
     clusterKey: ""
     clusterSecret: ""
-    secret: ""
+    adminToken: ""
+    authSecretName: ""
 
   ## Service configuration.
   ##
@@ -100,7 +113,7 @@ strongdm:
 
   ## Service account configuration.
   ##
-  ## @param strongdm.serviceAccount.create - Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.
+  ## @param strongdm.serviceAccount.create - Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.
   ## @param strongdm.serviceAccount.name - Name of an existing ServiceAccount to use.
   ## @param strongdm.serviceAccount.annotations - Map of annotations to add to the ServiceAccount, should one be created.
   ## @param strongdm.serviceAccount.labels - Map of labels to add to the ServiceAccount, should one be created.

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -38,7 +38,7 @@ strongdm:
       storage: stdout
       encryption: plaintext
 
-  ## Auto registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the support @strongdm.auth methods.
+  ## Auto registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
   ##
   ## @param strongdm.config.autoRegisterCluster.enabled - Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
   ## @param strongdm.config.autoRegisterCluster.resourceName - Name of the StrongDM Pod Identity Cluster resource to create.

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -48,19 +48,18 @@ strongdm:
     enabled: false
     resourceName: ""
     extraArgs: ""
-    adminToken: ""
 
   ## StrongDM authentication sources.
   ##
-  ## @param strongdm.auth.clusterKey - The SDM_PROXY_CLUSTER_ACCESS_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.authSecretName.
-  ## @param strongdm.auth.clusterSecret - The SDM_PROXY_CLUSTER_SECRET_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.authSecretName.
-  ## @param strongdm.auth.adminToken - The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.authSecretName.
-  ## @param strongdm.auth.authSecretName - Name of the k8s Secret that contains SDM_PROXY_CLUSTER_ACCESS_KEY and SDM_PROXY_CLUSTER_SECRET_KEY, and/or SDM_ADMIN_TOKEN.
+  ## @param strongdm.auth.clusterKey - The SDM_PROXY_CLUSTER_ACCESS_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+  ## @param strongdm.auth.clusterSecret - The SDM_PROXY_CLUSTER_SECRET_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+  ## @param strongdm.auth.adminToken - The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+  ## @param strongdm.auth.secretName - Name of the k8s Secret that contains SDM_PROXY_CLUSTER_ACCESS_KEY and SDM_PROXY_CLUSTER_SECRET_KEY, and/or SDM_ADMIN_TOKEN.
   auth:
     clusterKey: ""
     clusterSecret: ""
     adminToken: ""
-    authSecretName: ""
+    secretName: ""
 
   ## Service configuration.
   ##

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 1.0.1
+version: 1.0.2
 appVersion: 46.77.0
 description: StrongDM Relay
 type: application

--- a/deployments/sdm-relay/templates/Deployment.yaml
+++ b/deployments/sdm-relay/templates/Deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: SDM_RELAY_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.strongdm.auth.authSecretName | default (printf "%s-secrets" .Release.Name) }}
+                  name: {{ .Values.strongdm.auth.secretName | default (printf "%s-secrets" .Release.Name) }}
                   key: SDM_RELAY_TOKEN
           envFrom:
             - configMapRef:

--- a/deployments/sdm-relay/templates/Deployment.yaml
+++ b/deployments/sdm-relay/templates/Deployment.yaml
@@ -17,13 +17,11 @@ spec:
       {{- include "strongdm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      labels:
-        {{- include "strongdm.labels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- range $k, $v := .Values.strongdm.pod.annotations }}
-        {{ $k }}: {{ $v | quote }}
-        {{- end }}
+        {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.pod.annotations) .) | nindent 8 }}
+      labels:
+        {{- include "strongdm.labels" (merge (dict "addtl" .Values.strongdm.pod.labels) .) | nindent 8 }}
     spec:
       restartPolicy: Always
       {{- if or .Values.strongdm.serviceAccount.create .Values.strongdm.serviceAccount.name }}
@@ -42,16 +40,14 @@ spec:
                   containerName: sdm
                   resource: requests.cpu
                   divisor: "1"
+            - name: SDM_RELAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.strongdm.auth.authSecretName | default (printf "%s-secrets" .Release.Name) }}
+                  key: SDM_RELAY_TOKEN
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-config
-            {{- if .Values.strongdm.auth.token }}
-            - secretRef:
-                name: {{ .Release.Name }}-secrets
-            {{- else if .Values.strongdm.auth.tokenSecret }}
-            - secretRef:
-                name: {{ .Values.strongdm.auth.tokenSecret }}
-            {{- end }}
           ports:
             - name: healthcheck
               containerPort: 9090

--- a/deployments/sdm-relay/templates/Secret.yaml
+++ b/deployments/sdm-relay/templates/Secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.strongdm.auth.token }}
+{{- if not .Values.strongdm.auth.authSecretName }}
 ---
 apiVersion: v1
 kind: Secret
@@ -11,5 +11,6 @@ metadata:
     {{- include "strongdm.labels" . | nindent 4 }}
 type: Opaque
 data:
-  SDM_RELAY_TOKEN: {{ .Values.strongdm.auth.token | b64enc }}
+  SDM_RELAY_TOKEN: {{ .Values.strongdm.auth.relayToken | b64enc }}
+  SDM_ADMIN_TOKEN: {{ .Values.strongdm.auth.adminToken | b64enc }}
 {{- end }}

--- a/deployments/sdm-relay/templates/Secret.yaml
+++ b/deployments/sdm-relay/templates/Secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.strongdm.auth.authSecretName }}
+{{- if not .Values.strongdm.auth.secretName }}
 ---
 apiVersion: v1
 kind: Secret

--- a/deployments/sdm-relay/templates/post-install.yaml
+++ b/deployments/sdm-relay/templates/post-install.yaml
@@ -37,7 +37,7 @@ spec:
             - name: SDM_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.strongdm.auth.authSecretName | default (printf "%s-secrets" .Release.Name) }}
+                  name: {{ .Values.strongdm.auth.secretName | default (printf "%s-secrets" .Release.Name) }}
                   key: SDM_ADMIN_TOKEN
           envFrom:
             - configMapRef:

--- a/deployments/sdm-relay/templates/post-install.yaml
+++ b/deployments/sdm-relay/templates/post-install.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.strongdm.autoRegisterCluster.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-register-cluster
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-1"
+    {{- include "strongdm.annotations" . | nindent 4 }}
+  labels:
+    {{- include "strongdm.labels" . | nindent 4 }}
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      annotations:
+        {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.pod.annotations) .) | nindent 8 }}
+      labels:
+        {{- include "strongdm.labels" (merge (dict "addtl" .Values.strongdm.pod.labels) .) | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: sdm
+          image: {{ template "strongdm.imageURI" . }}
+          imagePullPolicy: {{ .Values.strongdm.image.pullPolicy }}
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 256m
+            limits:
+              memory: 256Mi
+          env:
+            - name: SDM_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.strongdm.auth.authSecretName | default (printf "%s-secrets" .Release.Name) }}
+                  key: SDM_ADMIN_TOKEN
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-config
+          command:
+            - /bin/bash
+            - -c
+            - |
+              /sdm.linux login --admin-token="${SDM_ADMIN_TOKEN}"
+              /sdm.linux admin clusters add k8spodidentity --certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt {{ .Values.strongdm.autoRegisterCluster.extraArgs }} {{ .Values.strongdm.autoRegisterCluster.resourceName | default (printf "%s-cluster-%s" .Release.Name (randAlpha 5)) }}
+{{- end}}

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -1,0 +1,211 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "global": {
+            "properties": {
+                "addDateLabel": {
+                    "type": "boolean"
+                },
+                "annotations": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "labels": {
+                    "properties": {},
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "strongdm": {
+            "properties": {
+                "auth": {
+                    "properties": {
+                        "adminToken": {
+                            "type": "string"
+                        },
+                        "authSecretName": {
+                            "type": "string"
+                        },
+                        "relayToken": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "autoRegisterCluster": {
+                    "properties": {
+                        "adminToken": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "extraArgs": {
+                            "type": "string"
+                        },
+                        "resourceName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "config": {
+                    "properties": {
+                        "disableAutoUpdate": {
+                            "type": "boolean"
+                        },
+                        "domain": {
+                            "type": "string"
+                        },
+                        "enableMetrics": {
+                            "type": "boolean"
+                        },
+                        "logOptions": {
+                            "properties": {
+                                "encryption": {
+                                    "type": "string"
+                                },
+                                "format": {
+                                    "type": "string"
+                                },
+                                "storage": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "maintenanceWindowStart": {
+                            "type": "integer"
+                        }
+                    },
+                    "type": "object"
+                },
+                "deployment": {
+                    "properties": {
+                        "annotations": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "labels": {
+                            "properties": {},
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "gateway": {
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "listenPort": {
+                            "type": "integer"
+                        },
+                        "service": {
+                            "properties": {
+                                "annotations": {
+                                    "properties": {},
+                                    "type": "object"
+                                },
+                                "labels": {
+                                    "properties": {},
+                                    "type": "object"
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string"
+                                },
+                                "nodePort": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "image": {
+                    "properties": {
+                        "digest": {
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "pod": {
+                    "properties": {
+                        "annotations": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "labels": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "resources": {
+                            "properties": {
+                                "limits": {
+                                    "properties": {
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "requests": {
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "string"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "serviceAccount": {
+                    "properties": {
+                        "annotations": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "labels": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "type": "object"
+}

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -24,10 +24,10 @@
                         "adminToken": {
                             "type": "string"
                         },
-                        "authSecretName": {
+                        "relayToken": {
                             "type": "string"
                         },
-                        "relayToken": {
+                        "secretName": {
                             "type": "string"
                         }
                     },
@@ -35,9 +35,6 @@
                 },
                 "autoRegisterCluster": {
                     "properties": {
-                        "adminToken": {
-                            "type": "string"
-                        },
                         "enabled": {
                             "type": "boolean"
                         },

--- a/deployments/sdm-relay/values.test.yaml
+++ b/deployments/sdm-relay/values.test.yaml
@@ -1,0 +1,9 @@
+## Test file to be merged with values.yaml.
+##
+## Set all "create" flags to true to exhaust as many config options as possible.
+##
+strongdm:
+  serviceAccount:
+    create: true
+  autoRegisterCluster:
+    enabled: true

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -111,7 +111,8 @@ strongdm:
 
   ## Service account configuration.
   ##
-  ## @param strongdm.serviceAccount.create - Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.
+  ## @param strongdm.serviceAccount.create - Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount, falling back to the default ServiceAccount for that namespace.
+
   ## @param strongdm.serviceAccount.name - Name of an existing ServiceAccount to use.
   ## @param strongdm.serviceAccount.annotations - Map of annotations to add to the ServiceAccount, should one be created.
   ## @param strongdm.serviceAccount.labels - Map of labels to add to the ServiceAccount, should one be created.

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -38,18 +38,32 @@ strongdm:
       storage: stdout
       encryption: plaintext
 
-  ## StrongDM authentication sources. Exactly one of the following must be provided.
+  ## Auto registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the support strongdm.auth methods.
   ##
-  ## @param strongdm.auth.token - The SDM_RELAY_TOKEN with which this relay should authenticate itself. Specify this directly, or provide an existing secret to strongdm.auth.tokenSecret.
-  ## @param strongdm.auth.tokenSecret - Name of the k8s Secret that contains SDM_RELAY_TOKEN.
+  ## @param strongdm.config.autoRegisterCluster.enabled - Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
+  ## @param strongdm.config.autoRegisterCluster.resourceName - Name of the StrongDM Pod Identity Cluster resource to create.
+  ## @param strongdm.config.autoRegisterCluster.extraArgs - Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.
+  ##
+  autoRegisterCluster:
+    enabled: false
+    resourceName: ""
+    extraArgs: ""
+    adminToken: ""
+
+  ## StrongDM authentication sources.
+  ##
+  ## @param strongdm.auth.relayToken - The SDM_RELAY_TOKEN with which this relay should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+  ## @param strongdm.auth.adminToken - The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.adminTokenSecret.
+  ## @param strongdm.auth.authSecretName - Name of the k8s Secret that contains SDM_RELAY_TOKEN and/or SDM_ADMIN_TOKEN.
   ##
   auth:
-    token: ""
-    tokenSecret: ""
+    relayToken: ""
+    adminToken: ""
+    authSecretName: ""
 
   ## Gateway configuration.
   ##
-  ## @param strongdm.gateway.enabled - Whether this is to be a StrongDM Gateway. If false, a Relay is created, and all other strongdm.gateway values are ignored.
+  ## @param strongdm.gateway.enabled - Whether this is to be a StrongDM Gateway. If false, a Relay is created, and all other @strongdm.gateway values are ignored.
   ## @param strongdm.gateway.listenPort - Port on which the Service is expecting traffic.
   ## @param strongdm.gateway.containerPort - Port on which the container runs.
   ##
@@ -58,7 +72,7 @@ strongdm:
     listenPort: 5000
     containerPort: 5000
 
-    ## Service configuration. Ignored unless strongdm.gateway.enabled.
+    ## Service configuration. Ignored unless @strongdm.gateway.enabled.
     ##
     ## @param strongdm.gateway.service.annotations - Map of annotations to apply to the Service.
     ## @param strongdm.gateway.service.labels - Map of labels to apply to the Service.
@@ -98,7 +112,7 @@ strongdm:
 
   ## Service account configuration.
   ##
-  ## @param strongdm.serviceAccount.create - Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.
+  ## @param strongdm.serviceAccount.create - Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.
   ## @param strongdm.serviceAccount.name - Name of an existing ServiceAccount to use.
   ## @param strongdm.serviceAccount.annotations - Map of annotations to add to the ServiceAccount, should one be created.
   ## @param strongdm.serviceAccount.labels - Map of labels to add to the ServiceAccount, should one be created.

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -48,18 +48,17 @@ strongdm:
     enabled: false
     resourceName: ""
     extraArgs: ""
-    adminToken: ""
 
   ## StrongDM authentication sources.
   ##
   ## @param strongdm.auth.relayToken - The SDM_RELAY_TOKEN with which this relay should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
-  ## @param strongdm.auth.adminToken - The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.adminTokenSecret.
-  ## @param strongdm.auth.authSecretName - Name of the k8s Secret that contains SDM_RELAY_TOKEN and/or SDM_ADMIN_TOKEN.
+  ## @param strongdm.auth.adminToken - The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+  ## @param strongdm.auth.secretName - Name of the k8s Secret that contains SDM_RELAY_TOKEN and/or SDM_ADMIN_TOKEN.
   ##
   auth:
     relayToken: ""
     adminToken: ""
-    authSecretName: ""
+    secretName: ""
 
   ## Gateway configuration.
   ##


### PR DESCRIPTION
- add `post-install` hook that creates a StrongDM Pod Identity Cluster resource.
- improve, simplify, and standardize how secrets are loaded into Pods.
- standardize the way we add annotations everywhere.
- beef up some of the pre-commit hooks with more test values, and introduce value schemas.

as an aside, there is lots of duplication between these two charts. i would love to introduce a pattern similar to what Bitnami does, wherein they publish a [common chart and include it as a dependency](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/Chart.yaml#L17-L22) in their actual charts. shared code and helpers can go there and greatly simplify the other charts. a task for another PR.

i was able to validate the post install hook in our sandbox environment. status is unhealthy but that's a quirk of the env, not the process that created the resource.
<img width="855" alt="Screenshot 2025-03-18 at 14 23 43" src="https://github.com/user-attachments/assets/d1613c6e-a8c1-403a-8224-1875ab59a767" />