### PR TITLE
allow overriding resource names and release namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@
 This repo contains the following packaged Helm charts provided by StrongDM:
 
 * [StrongDM Relay/Gateway](https://github.com/strongdm/charts/blob/main/deployments/sdm-relay/README.md)
-* [StrongDM Proxy Cluster](https://github.com/strongdm/charts/blob/main/deployments/sdm-proxy/README.md)
+* [StrongDM Proxy Worker](https://github.com/strongdm/charts/blob/main/deployments/sdm-proxy/README.md)
 * [StrongDM Client Container](https://github.com/strongdm/charts/blob/main/deployments/sdm-client/README.md)

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 1.0.4
+version: 1.0.5
 appVersion: 46.77.0
 description: StrongDM Proxy
 type: application

--- a/deployments/sdm-proxy/templates/NOTES.txt
+++ b/deployments/sdm-proxy/templates/NOTES.txt
@@ -5,4 +5,4 @@ Your release is named {{ .Release.Name }}. To learn more about the release, try:
   $ helm get all {{ .Release.Name }}
 
 Tail the application logs:
-  $ kubectl logs -n {{ .Release.Namespace }} -f -l app.kubernetes.io/name={{ .Chart.Name }} -l app.kubernetes.io/component=proxy
+  $ kubectl logs -n {{ include "strongdm.namespace" . }} -f -l app.kubernetes.io/name={{ .Chart.Name }} -l app.kubernetes.io/component=proxy

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -1,3 +1,10 @@
+{{- define "strongdm.name" -}}
+{{- default .Release.Name .Values.strongdm.nameOverride }}
+{{- end }}
+{{- define "strongdm.namespace" -}}
+{{- default .Release.Namespace .Values.strongdm.namespaceOverride }}
+{{- end }}
+
 # Args:
 # - addtl: (optional) map of annotations to add
 {{- define "strongdm.annotations" -}}

--- a/deployments/sdm-proxy/templates/configmap.yaml
+++ b/deployments/sdm-proxy/templates/configmap.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-config
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "strongdm.name" . }}-config
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:

--- a/deployments/sdm-proxy/templates/deployment.yaml
+++ b/deployments/sdm-proxy/templates/deployment.yaml
@@ -2,8 +2,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "strongdm.name" . }}
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.deployment.annotations) .) | nindent 4 }}
   labels:
@@ -66,7 +66,7 @@ spec:
                   key: SDM_PROXY_CLUSTER_SECRET_KEY
           envFrom:
             - configMapRef:
-                name: {{ .Release.Name }}-config
+                name: {{ include "strongdm.name" . }}-config
           ports:
             - name: healthcheck
               containerPort: 9090

--- a/deployments/sdm-proxy/templates/post-install.yaml
+++ b/deployments/sdm-proxy/templates/post-install.yaml
@@ -6,8 +6,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-register-cluster
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "strongdm.name" . }}-register-cluster
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-weight: "-1"
@@ -46,7 +46,7 @@ spec:
                   key: SDM_ADMIN_TOKEN
           envFrom:
             - configMapRef:
-                name: {{ .Release.Name }}-config
+                name: {{ include "strongdm.name" . }}-config
           command:
             - /bin/bash
             - -c

--- a/deployments/sdm-proxy/templates/secret.yaml
+++ b/deployments/sdm-proxy/templates/secret.yaml
@@ -6,8 +6,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-secrets
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "strongdm.name" . }}-secrets
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:

--- a/deployments/sdm-proxy/templates/service.yaml
+++ b/deployments/sdm-proxy/templates/service.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "strongdm.name" . }}
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.service.annotations) .) | nindent 4 }}
   labels:

--- a/deployments/sdm-proxy/templates/serviceaccount.yaml
+++ b/deployments/sdm-proxy/templates/serviceaccount.yaml
@@ -4,8 +4,8 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "strongdm.name" . }}
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.serviceAccount.annotations) .) | nindent 4 }}
   labels:

--- a/deployments/sdm-proxy/values.schema.json
+++ b/deployments/sdm-proxy/values.schema.json
@@ -77,9 +77,6 @@
                         },
                         "maintenanceWindowStart": {
                             "type": "integer"
-                        },
-                        "maintenanceWindows": {
-                            "type": "string"
                         }
                     },
                     "type": "object"
@@ -130,6 +127,12 @@
                         }
                     },
                     "type": "object"
+                },
+                "nameOverride": {
+                    "type": "string"
+                },
+                "namespaceOverride": {
+                    "type": "string"
                 },
                 "pod": {
                     "properties": {

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -10,6 +10,14 @@ global:
   labels: {}
 
 strongdm:
+  ## Allow some overrides. Useful when installing as a subchart.
+  ##
+  ## @param strongdm.nameOverride - Override resource names.
+  ## @param strongdm.namespaceOverride - Override the release namespace.
+  ##
+  nameOverride: ""
+  namespaceOverride: ""
+
   ## Image pull configuration.
   ##
   ## @param strongdm.image - Container repository and pull config.
@@ -24,7 +32,6 @@ strongdm:
   ##
   ## @param strongdm.config.domain - Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
   ## @param strongdm.config.disableAutoUpdate - Disable automatically checking for and applying updates.
-  ## @param strongdm.config.maintenanceWindows - Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6;* * * * *'.
   ## @param strongdm.config.maintenanceWindowStart - Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
   ## @param strongdm.config.enableMetrics - Enable Prometheus metrics on port 9999.
   ## @param strongdm.config.logOptions - Configuration for container logs.
@@ -32,7 +39,6 @@ strongdm:
   config:
     domain: strongdm.com
     disableAutoUpdate: false
-    maintenanceWindows: '* * * * *'
     maintenanceWindowStart: 0
     enableMetrics: false
     logOptions:

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 1.0.4
+version: 1.0.5
 appVersion: 46.77.0
 description: StrongDM Relay
 type: application

--- a/deployments/sdm-relay/templates/NOTES.txt
+++ b/deployments/sdm-relay/templates/NOTES.txt
@@ -5,4 +5,4 @@ Your release is named {{ .Release.Name }}. To learn more about the release, try:
   $ helm get all {{ .Release.Name }}
 
 Tail the application logs:
-  $ kubectl logs -n {{ .Release.Namespace }} -f -l app.kubernetes.io/name={{ .Chart.Name }} -l app.kubernetes.io/component={{ .Values.strongdm.gateway.enabled | ternary "gateway" "relay" }}
+  $ kubectl logs -n {{ include "strongdm.namespace" . }} -f -l app.kubernetes.io/name={{ .Chart.Name }} -l app.kubernetes.io/component={{ .Values.strongdm.gateway.enabled | ternary "gateway" "relay" }}

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -1,3 +1,10 @@
+{{- define "strongdm.name" -}}
+{{- default .Release.Name .Values.strongdm.nameOverride }}
+{{- end }}
+{{- define "strongdm.namespace" -}}
+{{- default .Release.Namespace .Values.strongdm.namespaceOverride }}
+{{- end }}
+
 # Args:
 # - addtl: (optional) map of annotations to add
 {{- define "strongdm.annotations" -}}

--- a/deployments/sdm-relay/templates/configmap.yaml
+++ b/deployments/sdm-relay/templates/configmap.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-config
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "strongdm.name" . }}-config
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:

--- a/deployments/sdm-relay/templates/deployment.yaml
+++ b/deployments/sdm-relay/templates/deployment.yaml
@@ -2,8 +2,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "strongdm.name" . }}
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.deployment.annotations) .) | nindent 4 }}
   labels:

--- a/deployments/sdm-relay/templates/post-install.yaml
+++ b/deployments/sdm-relay/templates/post-install.yaml
@@ -6,8 +6,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-register-cluster
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "strongdm.name" . }}-register-cluster
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-weight: "-1"

--- a/deployments/sdm-relay/templates/pre-install.yaml
+++ b/deployments/sdm-relay/templates/pre-install.yaml
@@ -119,7 +119,7 @@ spec:
             - -c
             - |
               /sdm.linux login --admin-token="${SDM_ADMIN_TOKEN}"
-            {{- $commonArgs := printf "--maintenance-windows %s --name %s --tags %s" (squote .Values.strongdm.config.maintenanceWindows) (squote .Values.strongdm.autoCreateNode.name) (squote .Values.strongdm.autoCreateNode.tags) }}
+            {{- $commonArgs := printf "--maintenance-windows %s --name %s --tags %s" (squote .Values.strongdm.autoCreateNode.maintenanceWindows) (squote .Values.strongdm.autoCreateNode.name) (squote .Values.strongdm.autoCreateNode.tags) }}
             {{- if .Values.strongdm.gateway.enabled }}
               echo "SDM_RELAY_TOKEN=$(/sdm.linux admin node create-gateway {{ $commonArgs }} {{ .Values.strongdm.gateway.listenAddress }}:{{ .Values.strongdm.gateway.listenPort }})" > /secrets/token
             {{- else }}

--- a/deployments/sdm-relay/templates/pre-install.yaml
+++ b/deployments/sdm-relay/templates/pre-install.yaml
@@ -2,14 +2,14 @@
 {{- if not (or .Values.strongdm.auth.secretName .Values.strongdm.auth.adminToken) }}
 {{- fail "one of @strongdm.auth.adminToken or @strongdm.auth.secretName must be set when @strongdm.autoCreateNode.enabled during installation." }}
 {{- end }}
-{{ $name := printf "%s-auto-create-node-%s" .Release.Name (randAlpha 5 | lower) }}
+{{ $name := printf "%s-auto-create-node-%s" (include "strongdm.name" .) (randAlpha 5 | lower) }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   name: {{ $name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-3"
@@ -23,7 +23,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-3"
@@ -41,7 +41,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-2"
@@ -52,7 +52,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ $name }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "strongdm.namespace" . }}
 roleRef:
   kind: Role
   name: {{ $name }}
@@ -63,7 +63,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ $name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-1"
@@ -143,5 +143,5 @@ spec:
           command:
             - /bin/bash
             - -c
-            - kubectl create secret generic {{ .Release.Name }}-relay-token --from-literal=$(cat /secrets/token) --namespace {{ .Release.Namespace }} --dry-run=client -o yaml | kubectl apply -f -
+            - kubectl create secret generic {{ .Release.Name }}-relay-token --from-literal=$(cat /secrets/token) --namespace {{ include "strongdm.namespace" . }} --dry-run=client -o yaml | kubectl apply -f -
 {{- end }}

--- a/deployments/sdm-relay/templates/secret.yaml
+++ b/deployments/sdm-relay/templates/secret.yaml
@@ -6,8 +6,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-secrets
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "strongdm.name" . }}-secrets
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:

--- a/deployments/sdm-relay/templates/service.yaml
+++ b/deployments/sdm-relay/templates/service.yaml
@@ -3,8 +3,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "strongdm.name" . }}
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.gateway.service.annotations) .) | nindent 4 }}
   labels:

--- a/deployments/sdm-relay/templates/serviceaccount.yaml
+++ b/deployments/sdm-relay/templates/serviceaccount.yaml
@@ -4,8 +4,8 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "strongdm.name" . }}
+  namespace: {{ include "strongdm.namespace" . }}
   annotations:
     {{- include "strongdm.annotations" (merge (dict "addtl" .Values.strongdm.serviceAccount.annotations) .) | nindent 4 }}
   labels:

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -38,6 +38,9 @@
                         "enabled": {
                             "type": "boolean"
                         },
+                        "maintenanceWindows": {
+                            "type": "string"
+                        },
                         "name": {
                             "type": "string"
                         },
@@ -88,9 +91,6 @@
                         },
                         "maintenanceWindowStart": {
                             "type": "integer"
-                        },
-                        "maintenanceWindows": {
-                            "type": "string"
                         }
                     },
                     "type": "object"
@@ -163,6 +163,12 @@
                         }
                     },
                     "type": "object"
+                },
+                "nameOverride": {
+                    "type": "string"
+                },
+                "namespaceOverride": {
+                    "type": "string"
                 },
                 "pod": {
                     "properties": {

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -60,15 +60,15 @@ strongdm:
   ## Auto creation configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
   ##
   ## @param strongdm.autoCreateNode.enabled - Create this StrongDM Relay or Gateway automatically.
-  ## @param strongdm.autoCreateNode.maintenanceWindows - Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6;* * * * *'.
   ## @param strongdm.autoCreateNode.name - Name of the Node as it should appear in StrongDM.
   ## @param strongdm.autoCreateNode.tags - Tags to add to the created Node. Format 'key=value,key2=value2'.
+  ## @param strongdm.autoCreateNode.maintenanceWindows - Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6;* * * * *'.
   ##
   autoCreateNode:
     enabled: true
-    maintenanceWindows: '* * * * *'
     name: ""
     tags: ""
+    maintenanceWindows: '* * * * *'
 
   ## StrongDM authentication sources.
   ##

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -10,6 +10,14 @@ global:
   labels: {}
 
 strongdm:
+  ## Allow some overrides. Useful when installing as a subchart.
+  ##
+  ## @param strongdm.nameOverride - Override resource names.
+  ## @param strongdm.namespaceOverride - Override the release namespace.
+  ##
+  nameOverride: ""
+  namespaceOverride: ""
+
   ## Image pull configuration.
   ##
   ## @param strongdm.image - Container repository and pull config.
@@ -24,7 +32,6 @@ strongdm:
   ##
   ## @param strongdm.config.domain - Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
   ## @param strongdm.config.disableAutoUpdate - Disable automatically checking for and applying updates.
-  ## @param strongdm.config.maintenanceWindows - Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6;* * * * *'.
   ## @param strongdm.config.maintenanceWindowStart - Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
   ## @param strongdm.config.enableMetrics - Enable Prometheus metrics on port 9999.
   ## @param strongdm.config.logOptions - Configuration for container logs.
@@ -32,7 +39,6 @@ strongdm:
   config:
     domain: strongdm.com
     disableAutoUpdate: false
-    maintenanceWindows: '* * * * *'
     maintenanceWindowStart: 0
     enableMetrics: false
     logOptions:
@@ -40,7 +46,7 @@ strongdm:
       storage: stdout
       encryption: plaintext
 
-  ## Auto registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the support @strongdm.auth methods.
+  ## Auto registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
   ##
   ## @param strongdm.autoRegisterCluster.enabled - Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
   ## @param strongdm.autoRegisterCluster.resourceName - Name of the StrongDM Pod Identity Cluster resource to create.
@@ -54,11 +60,13 @@ strongdm:
   ## Auto creation configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
   ##
   ## @param strongdm.autoCreateNode.enabled - Create this StrongDM Relay or Gateway automatically.
+  ## @param strongdm.autoCreateNode.maintenanceWindows - Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6;* * * * *'.
   ## @param strongdm.autoCreateNode.name - Name of the Node as it should appear in StrongDM.
   ## @param strongdm.autoCreateNode.tags - Tags to add to the created Node. Format 'key=value,key2=value2'.
   ##
   autoCreateNode:
     enabled: true
+    maintenanceWindows: '* * * * *'
     name: ""
     tags: ""
 


### PR DESCRIPTION
Addresses https://github.com/strongdm/charts/issues/8. Inspiration taken from the [Bitnami Helm charts](https://github.com/bitnami/charts/pull/30113).

Also removes the unused `maintenanceWindows` from `sdm-proxy`, and that value under `autoCreateNode` in `sdm-relay` next to the other values that configure that pre-install hook.

QA plan
---
With the following local setup:
```
~/scratch/helm: tree .
.
├── test-chart
│   ├── Chart.yaml
│   ├── templates
│   │   └── pod.yaml
│   └── values.yaml
└── values.yaml
```

Where `Chart.yaml` points to a local repo:
```yaml
apiVersion: v2
name: test
description: "Local Helm testing"
version: 0.1.0
dependencies:
- name: sdm-relay
  version: 1.0.5
  repository: file:///Users/kellen.anker/git/charts/deployments/sdm-relay
```

and the applied `values.yaml` is:
```yaml
name: parent

sdm-relay:
  strongdm:
    nameOverride: child
    namespaceOverride: foobar
    auth:
      adminToken: foo
```

I am able to run `helm dep update test-chart`, then  `helm template test-chart -f values.yaml` and see the following successful results (trimmed for brevity):
```yaml
# Source: test/templates/pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: parent
  namespace: default
...

# Source: test/charts/sdm-relay/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: child # name override
  namespace: foobar # namespace override
...
```

And when removing the overrides, confirmed we use the release name and namespace in both the parent chart and its subchart:
```yaml
# Source: test/templates/pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: parent
  namespace: default
...

# Source: test/charts/sdm-relay/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name
  namespace: default
...
```