### PR TITLE
pin to latest because nodes auto update by default

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Description of changes
+
+<!--
+Describe your changes.
+-->
+
+## Validation steps
+
+<!--
+Add any additional context you deem helpful.
+-->
+
+- [ ] went through the local validation steps in [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
+- [ ] (optionally) deployed this change to k8s cluster.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-If you would like to suggest changes, please file a Pull Request in this repository. Our team will review and communicate via the Pull Request.
+If you would like to suggest changes, please create an issue in this project. We also accept Pull Requests.

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,14 +1,13 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 1.0.5
-appVersion: 46.77.0
+version: 1.0.6
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png
 home: https://github.com/strongdm/charts
 maintainers:
-  - name: strongDM
+  - name: StrongDM
     email: k8s+sdm@strongdm.com
 sources:
   - https://github.com/strongdm/charts/tree/main/deployments/sdm-proxy

--- a/deployments/sdm-proxy/README.md
+++ b/deployments/sdm-proxy/README.md
@@ -14,7 +14,7 @@ This repo provides an implementation of a StrongDM proxy service inside Kubernet
 * Helm 3.0+
 * Git
 * If you are going to use [Nginx Ingress Controller](https://kubernetes.github.io/ingress-nginx/), then you will need to manually patch your [services to allow TCP and UDP traffic](https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/)
-* A StrongDM Proxy Cluster key and secret.
+* A [StrongDM Proxy Cluster key and secret](https://www.strongdm.com/docs/admin/proxy-clusters)
 
 > [!NOTE]
 > To get a Proxy Cluster key and secret, you'll need an external address to register. If you don't have such an address during installation of this chart, you may create a cluster in the Admin UI with a placeholder name. You may change that value after creation with the StrongDM CLI.

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -58,8 +58,8 @@ resources:
 # - digest: (optional) image digest
 {{- define "strongdm.imageURI" -}}
 {{- if .Values.strongdm.image.digest -}}
-{{ printf "%s@sha256:%s" (.repository | default "public.ecr.aws/strongdm/relay") .Values.strongdm.image.digest }}
+{{ printf "%s@sha256:%s" (default "public.ecr.aws/strongdm/relay" .repository) .Values.strongdm.image.digest }}
 {{- else -}}
-{{ printf "%s:%s" (.repository | default "public.ecr.aws/strongdm/relay") (.Values.strongdm.image.tag | default .Chart.AppVersion) }}
+{{ printf "%s:%s" (default "public.ecr.aws/strongdm/relay" .repository) .Values.strongdm.image.tag }}
 {{- end -}}
 {{- end }}

--- a/deployments/sdm-proxy/templates/configmap.yaml
+++ b/deployments/sdm-proxy/templates/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "strongdm.labels" . | nindent 4 }}
 data:
   SDM_DOMAIN: {{ .Values.strongdm.config.domain }}
-  SDM_DISABLE_UPDATE: {{ .Values.strongdm.config.disableAutoUpdate | quote }}
+  SDM_DISABLE_UPDATE: {{ or .Values.strongdm.config.disableAutoUpdate .Values.strongdm.image.digest (ne .Values.strongdm.image.tag "latest") | quote }}
   SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
   SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.logOptions.format }}
   SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.logOptions.storage }}

--- a/deployments/sdm-proxy/templates/deployment.yaml
+++ b/deployments/sdm-proxy/templates/deployment.yaml
@@ -57,12 +57,12 @@ spec:
             - name: SDM_PROXY_CLUSTER_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.strongdm.auth.secretName | default (printf "%s-secrets" .Release.Name) }}
+                  name: {{ default (printf "%s-secrets" .Release.Name) .Values.strongdm.auth.secretName }}
                   key: SDM_PROXY_CLUSTER_ACCESS_KEY
             - name: SDM_PROXY_CLUSTER_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.strongdm.auth.secretName | default (printf "%s-secrets" .Release.Name) }}
+                  name: {{ default (printf "%s-secrets" .Release.Name) .Values.strongdm.auth.secretName }}
                   key: SDM_PROXY_CLUSTER_SECRET_KEY
           envFrom:
             - configMapRef:

--- a/deployments/sdm-proxy/templates/post-install.yaml
+++ b/deployments/sdm-proxy/templates/post-install.yaml
@@ -42,7 +42,7 @@ spec:
             - name: SDM_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.strongdm.auth.secretName | default (printf "%s-secrets" .Release.Name) }}
+                  name: {{ default (printf "%s-secrets" .Release.Name) .Values.strongdm.auth.secretName }}
                   key: SDM_ADMIN_TOKEN
           envFrom:
             - configMapRef:
@@ -55,5 +55,5 @@ spec:
               /sdm.linux admin clusters add k8spodidentity \
                 --certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 {{ .Values.strongdm.autoRegisterCluster.extraArgs }} \
-                {{ .Values.strongdm.autoRegisterCluster.resourceName | default (printf "%s-cluster-%s" .Release.Name (randAlpha 5)) }}
+                {{ default (printf "%s-cluster-%s" .Release.Name (randAlpha 5)) .Values.strongdm.autoRegisterCluster.resourceName }}
 {{- end}}

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -20,7 +20,7 @@ strongdm:
 
   ## Image pull configuration.
   ##
-  ## @param strongdm.image - Container repository and pull config.
+  ## @param strongdm.image - Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, @strongdm.config.disableAutoUpdate is automatically set to `true`.
   ##
   image:
     pullPolicy: IfNotPresent
@@ -31,7 +31,7 @@ strongdm:
   ## General configuration.
   ##
   ## @param strongdm.config.domain - Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
-  ## @param strongdm.config.disableAutoUpdate - Disable automatically checking for and applying updates.
+  ## @param strongdm.config.disableAutoUpdate - Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
   ## @param strongdm.config.maintenanceWindowStart - Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
   ## @param strongdm.config.enableMetrics - Enable Prometheus metrics on port 9999.
   ## @param strongdm.config.logOptions - Configuration for container logs.

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -25,7 +25,7 @@ strongdm:
   image:
     pullPolicy: IfNotPresent
     repository: public.ecr.aws/strongdm/relay
-    tag: ""
+    tag: latest
     digest: ""
 
   ## General configuration.

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -20,7 +20,7 @@ strongdm:
 
   ## Image pull configuration.
   ##
-  ## @param strongdm.image - Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, @strongdm.config.disableAutoUpdate is automatically set to `true`.
+  ## @param strongdm.image - Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
   ##
   image:
     pullPolicy: IfNotPresent

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,8 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 1.0.5
-appVersion: 46.77.0
+version: 1.0.6
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/README.md
+++ b/deployments/sdm-relay/README.md
@@ -8,8 +8,6 @@
 
 This repo provides an implementation of a StrongDM relay or gateway inside Kubernetes using Helm.
 
-[Learn more about deploying StrongDM inside Kubernetes on our docs site.](https://www.strongdm.com/docs/installation/install-your-gateway/kubernetes-gateways)
-
 ## Prerequisites
 
 * A Kubernetes Cluster v1.16+

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -62,8 +62,8 @@ resources:
 # - digest: (optional) image digest
 {{- define "strongdm.imageURI" -}}
 {{- if .Values.strongdm.image.digest -}}
-{{ printf "%s@sha256:%s" (.repository | default "public.ecr.aws/strongdm/relay") .Values.strongdm.image.digest }}
+{{ printf "%s@sha256:%s" (default "public.ecr.aws/strongdm/relay" .repository) .Values.strongdm.image.digest }}
 {{- else -}}
-{{ printf "%s:%s" (.repository | default "public.ecr.aws/strongdm/relay") (.Values.strongdm.image.tag | default .Chart.AppVersion) }}
+{{ printf "%s:%s" (default "public.ecr.aws/strongdm/relay" .repository) .Values.strongdm.image.tag }}
 {{- end -}}
 {{- end }}

--- a/deployments/sdm-relay/templates/configmap.yaml
+++ b/deployments/sdm-relay/templates/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "strongdm.labels" . | nindent 4 }}
 data:
   SDM_DOMAIN: {{ .Values.strongdm.config.domain }}
-  SDM_DISABLE_UPDATE: {{ .Values.strongdm.config.disableAutoUpdate | quote }}
+  SDM_DISABLE_UPDATE: {{ or .Values.strongdm.config.disableAutoUpdate .Values.strongdm.image.digest (ne .Values.strongdm.image.tag "latest") | quote }}
   SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
   SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.logOptions.format }}
   SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.logOptions.storage }}

--- a/deployments/sdm-relay/templates/deployment.yaml
+++ b/deployments/sdm-relay/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: SDM_RELAY_TOKEN
-                  name: {{ .Values.strongdm.autoCreateNode.enabled | ternary (printf "%s-relay-token" .Release.Name) (.Values.strongdm.auth.secretName | default (printf "%s-secrets" .Release.Name)) }}
+                  name: {{ .Values.strongdm.autoCreateNode.enabled | ternary (printf "%s-relay-token" .Release.Name) (default (printf "%s-secrets" .Release.Name) .Values.strongdm.auth.secretName) }}
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-config

--- a/deployments/sdm-relay/templates/post-install.yaml
+++ b/deployments/sdm-relay/templates/post-install.yaml
@@ -42,7 +42,7 @@ spec:
             - name: SDM_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.strongdm.auth.secretName | default (printf "%s-secrets" .Release.Name) }}
+                  name: {{ default (printf "%s-secrets" .Release.Name) .Values.strongdm.auth.secretName }}
                   key: SDM_ADMIN_TOKEN
           envFrom:
             - configMapRef:
@@ -55,5 +55,5 @@ spec:
               /sdm.linux admin clusters add k8spodidentity \
                 --certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 {{ .Values.strongdm.autoRegisterCluster.extraArgs }} \
-                {{ .Values.strongdm.autoRegisterCluster.resourceName | default (printf "%s-cluster-%s" .Release.Name (randAlpha 5)) }}
+                {{ default (printf "%s-cluster-%s" .Release.Name (randAlpha 5)) .Values.strongdm.autoRegisterCluster.resourceName }}
 {{- end}}

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -20,7 +20,7 @@ strongdm:
 
   ## Image pull configuration.
   ##
-  ## @param strongdm.image - Container repository and pull config.
+  ## @param strongdm.image - Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, @strongdm.config.disableAutoUpdate is automatically set to `true`.
   ##
   image:
     pullPolicy: IfNotPresent
@@ -31,7 +31,7 @@ strongdm:
   ## General configuration.
   ##
   ## @param strongdm.config.domain - Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
-  ## @param strongdm.config.disableAutoUpdate - Disable automatically checking for and applying updates.
+  ## @param strongdm.config.disableAutoUpdate - Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
   ## @param strongdm.config.maintenanceWindowStart - Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
   ## @param strongdm.config.enableMetrics - Enable Prometheus metrics on port 9999.
   ## @param strongdm.config.logOptions - Configuration for container logs.

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -25,7 +25,7 @@ strongdm:
   image:
     pullPolicy: IfNotPresent
     repository: public.ecr.aws/strongdm/relay
-    tag: ""
+    tag: latest
     digest: ""
 
   ## General configuration.

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -20,7 +20,7 @@ strongdm:
 
   ## Image pull configuration.
   ##
-  ## @param strongdm.image - Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, @strongdm.config.disableAutoUpdate is automatically set to `true`.
+  ## @param strongdm.image - Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
   ##
   image:
     pullPolicy: IfNotPresent


### PR DESCRIPTION
- the default behavior for these containers is to automatically update themselves to the latest available version. as such, it's a bit misleading to pin to an `appVersion` after all. the field is optional in `Chart.yaml` so we're free to remove it. this sets a new default `strongdm.image.tag=latest`.
- users can still _implicitly_ version-pin by setting either `strongdm.image.digest` to any value or `strongdm.image.tag` to anything not "latest". `strongdm.config.disableAutoUpdate` is still available to explicitly pin to the current version.
- standardize on one way to use `default`.
- add a PR template.