### PR TITLE
Proxy tls options

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,12 @@
 ## Description of changes
-
 <!--
 Describe your changes.
 -->
 
 ## Validation steps
-
 <!--
 Add any additional context you deem helpful.
 -->
 
-- [ ] went through the local validation steps in [CONTRIBUTING.md](../CONTRIBUTING.md)
 - [ ] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
 - [ ] (optionally) deployed this change to k8s cluster.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,11 @@ repos:
         entry: /bin/bash -c '! helm template deployments/sdm-proxy'
         language: system
         pass_filenames: false
+    -   id: template-invalid-tls-proxy-failure
+        name: Helm template | invalid TLS fail | proxy
+        entry: /bin/bash -c '! helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.test.yaml --set strongdm.service.tlsSource=file'
+        language: system
+        pass_filenames: false
 
     # Check version pin paths
     -   id: template-tag-pin-relay

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 1.0.6
+version: 1.0.7-pre1
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/configmap.yaml
+++ b/deployments/sdm-proxy/templates/configmap.yaml
@@ -17,3 +17,8 @@ data:
   SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.logOptions.encryption }}
   SDM_ORCHESTRATOR_PROBES: :9090
   SDM_METRICS_LISTEN_ADDRESS: {{ .Values.strongdm.config.enableMetrics | ternary ":9999" "" }}
+  SDM_TLS_CERT_SOURCE: {{ .Values.strongdm.service.tlsSource }}
+  {{- if .Values.strongdm.service.tlsSecretName }}
+  SDM_TLS_CERT_FILE: /etc/sdm/tls.crt
+  SDM_TLS_KEY_FILE: /etc/sdm/tls.key
+  {{- end }}

--- a/deployments/sdm-proxy/templates/configmap.yaml
+++ b/deployments/sdm-proxy/templates/configmap.yaml
@@ -1,3 +1,6 @@
+{{- if and (eq .Values.strongdm.service.tlsSource "file") (not .Values.strongdm.service.tlsSecretName) }}
+{{- fail "@strongdm.service.tlsSecretName must be set when @strongdm.service.tlsSource is 'file'." }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deployments/sdm-proxy/templates/deployment.yaml
+++ b/deployments/sdm-proxy/templates/deployment.yaml
@@ -41,6 +41,12 @@ spec:
             matchLabelKeys:
               - pod-template-hash
             {{- end }}
+      {{- if .Values.strongdm.service.tlsSecretName }}
+      volumes:
+        - name: {{ .Release.Name }}-tls
+          secret:
+            secretName: {{ .Values.strongdm.service.tlsSecretName }}
+      {{- end }}
       containers:
         - name: sdm
           image: {{ template "strongdm.imageURI" . }}
@@ -79,6 +85,12 @@ spec:
               containerPort: 9999
               protocol: TCP
             {{- end }}
+          {{- if .Values.strongdm.service.tlsSecretName }}
+          volumeMounts:
+            - name: {{ .Release.Name }}-tls
+              mountPath: /etc/sdm
+              readOnly: true
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /liveness

--- a/deployments/sdm-proxy/values.schema.json
+++ b/deployments/sdm-proxy/values.schema.json
@@ -4,13 +4,16 @@
         "global": {
             "properties": {
                 "addDateLabel": {
+                    "description": "Adds a `date: {{ now | htmlDate }}` label to all resources.",
                     "type": "boolean"
                 },
                 "annotations": {
+                    "description": "Map of annotations to add to all resources.",
                     "properties": {},
                     "type": "object"
                 },
                 "labels": {
+                    "description": "Map of labels to add to all resources.",
                     "properties": {},
                     "type": "object"
                 }
@@ -22,15 +25,19 @@
                 "auth": {
                     "properties": {
                         "adminToken": {
+                            "description": "The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.",
                             "type": "string"
                         },
                         "clusterKey": {
+                            "description": "The SDM_PROXY_CLUSTER_ACCESS_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.",
                             "type": "string"
                         },
                         "clusterSecret": {
+                            "description": "The SDM_PROXY_CLUSTER_SECRET_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.",
                             "type": "string"
                         },
                         "secretName": {
+                            "description": "Name of the k8s Secret that contains SDM_PROXY_CLUSTER_ACCESS_KEY and SDM_PROXY_CLUSTER_SECRET_KEY, and/or SDM_ADMIN_TOKEN.",
                             "type": "string"
                         }
                     },
@@ -39,12 +46,15 @@
                 "autoRegisterCluster": {
                     "properties": {
                         "enabled": {
+                            "description": "Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.",
                             "type": "boolean"
                         },
                         "extraArgs": {
+                            "description": "Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.",
                             "type": "string"
                         },
                         "resourceName": {
+                            "description": "Name of the StrongDM Pod Identity Cluster resource to create.",
                             "type": "string"
                         }
                     },
@@ -53,15 +63,19 @@
                 "config": {
                     "properties": {
                         "disableAutoUpdate": {
+                            "description": "Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.",
                             "type": "boolean"
                         },
                         "domain": {
+                            "description": "Control plane domain to which to connect. Format `uk.strongdm.com`, etc.",
                             "type": "string"
                         },
                         "enableMetrics": {
+                            "description": "Enable Prometheus metrics on port 9999.",
                             "type": "boolean"
                         },
                         "logOptions": {
+                            "description": "Configuration for container logs.",
                             "properties": {
                                 "encryption": {
                                     "type": "string"
@@ -76,6 +90,7 @@
                             "type": "object"
                         },
                         "maintenanceWindowStart": {
+                            "description": "Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.",
                             "type": "integer"
                         }
                     },
@@ -84,17 +99,21 @@
                 "deployment": {
                     "properties": {
                         "annotations": {
+                            "description": "Map of annotations to add to the Deployment.",
                             "properties": {},
                             "type": "object"
                         },
                         "labels": {
+                            "description": "Map of labels to add to the Deployment.",
                             "properties": {},
                             "type": "object"
                         },
                         "replicaCount": {
+                            "description": "Number of Pods to run in the deployment.",
                             "type": "integer"
                         },
                         "topologySpreadConstraints": {
+                            "description": "Pod spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.",
                             "properties": {
                                 "maxSkew": {
                                     "type": "integer"
@@ -112,6 +131,7 @@
                     "type": "object"
                 },
                 "image": {
+                    "description": "Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.",
                     "properties": {
                         "digest": {
                             "type": "string"
@@ -129,22 +149,27 @@
                     "type": "object"
                 },
                 "nameOverride": {
+                    "description": "Override resource names.",
                     "type": "string"
                 },
                 "namespaceOverride": {
+                    "description": "Override the release namespace.",
                     "type": "string"
                 },
                 "pod": {
                     "properties": {
                         "annotations": {
+                            "description": "Map of annotations to add to Pods.",
                             "properties": {},
                             "type": "object"
                         },
                         "labels": {
+                            "description": "Map of labels to add to Pods.",
                             "properties": {},
                             "type": "object"
                         },
                         "resources": {
+                            "description": "Set the Pod resource requests and limits.",
                             "properties": {
                                 "limits": {
                                     "properties": {
@@ -174,26 +199,41 @@
                 "service": {
                     "properties": {
                         "annotations": {
+                            "description": "Map of annotations to apply to the Service.",
                             "properties": {},
                             "type": "object"
                         },
                         "containerPort": {
+                            "description": "Port on which the Service is expecting traffic.",
                             "type": "integer"
                         },
                         "labels": {
+                            "description": "Map of labels to apply to the Service.",
                             "properties": {},
                             "type": "object"
                         },
                         "listenPort": {
+                            "description": "Port on which the container runs.",
                             "type": "integer"
                         },
                         "loadBalancerIP": {
+                            "description": "IP address to which to pin a LoadBalancer Service.",
                             "type": "string"
                         },
                         "nodePort": {
+                            "description": "NodePort to which to bind this service, if desired.",
                             "type": "integer"
                         },
+                        "tlsSecretName": {
+                            "description": "kubernetes.io/tls Secret with which containers will terminate TLS.",
+                            "type": "string"
+                        },
+                        "tlsSource": {
+                            "description": "How this service is expected to terminate TLS, if at all. Set to `file` and supply @strongdm.service.tlsSecretName to terminate with a user-provided certificate. Set to `none` if terminating TLS before these containers, e.g. with a load balancer. Leave empty to terminate TLS with a StrongDM-signed certificate built into the software.",
+                            "type": "string"
+                        },
                         "type": {
+                            "description": "Specify the type of Service to front the deployment.",
                             "type": "string"
                         }
                     },
@@ -202,17 +242,21 @@
                 "serviceAccount": {
                     "properties": {
                         "annotations": {
+                            "description": "Map of annotations to add to the ServiceAccount, should one be created.",
                             "properties": {},
                             "type": "object"
                         },
                         "create": {
+                            "description": "Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.",
                             "type": "boolean"
                         },
                         "labels": {
+                            "description": "Map of labels to add to the ServiceAccount, should one be created.",
                             "properties": {},
                             "type": "object"
                         },
                         "name": {
+                            "description": "Name of an existing ServiceAccount to use.",
                             "type": "string"
                         }
                     },

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -1,28 +1,19 @@
 global:
   ## Metadata applied to all resources.
   ##
-  ## @param global.addDateLabel - Adds a 'date: {{ now | htmlDate }}' label to all resources.
-  ## @param global.annotations - Map of annotations to add to all resources.
-  ## @param global.labels - Map of labels to add to all resources.
-  ##
-  addDateLabel: true
-  annotations: {}
-  labels: {}
+  addDateLabel: true # @schema; description: Adds a `date: {{ now | htmlDate }}` label to all resources.
+  annotations: {} # @schema; description: Map of annotations to add to all resources.
+  labels: {} # @schema; description: Map of labels to add to all resources.
 
 strongdm:
   ## Allow some overrides. Useful when installing as a subchart.
   ##
-  ## @param strongdm.nameOverride - Override resource names.
-  ## @param strongdm.namespaceOverride - Override the release namespace.
-  ##
-  nameOverride: ""
-  namespaceOverride: ""
+  nameOverride: "" # @schema; description: Override resource names.
+  namespaceOverride: "" # @schema; description: Override the release namespace.
 
   ## Image pull configuration.
   ##
-  ## @param strongdm.image - Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
-  ##
-  image:
+  image: # @schema; description: Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
     pullPolicy: IfNotPresent
     repository: public.ecr.aws/strongdm/relay
     tag: latest
@@ -30,88 +21,61 @@ strongdm:
 
   ## General configuration.
   ##
-  ## @param strongdm.config.domain - Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
-  ## @param strongdm.config.disableAutoUpdate - Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
-  ## @param strongdm.config.maintenanceWindowStart - Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
-  ## @param strongdm.config.enableMetrics - Enable Prometheus metrics on port 9999.
-  ## @param strongdm.config.logOptions - Configuration for container logs.
-  ##
   config:
-    domain: strongdm.com
-    disableAutoUpdate: false
-    maintenanceWindowStart: 0
-    enableMetrics: false
-    logOptions:
+    domain: strongdm.com # @schema; description: Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
+    disableAutoUpdate: false # @schema; description: Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
+    maintenanceWindowStart: 0 # @schema; description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
+    enableMetrics: false # @schema; description: Enable Prometheus metrics on port 9999.
+    logOptions: # @schema; description: Configuration for container logs.
       format: json
       storage: stdout
       encryption: plaintext
 
   ## Auto registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
   ##
-  ## @param strongdm.autoRegisterCluster.enabled - Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
-  ## @param strongdm.autoRegisterCluster.resourceName - Name of the StrongDM Pod Identity Cluster resource to create.
-  ## @param strongdm.autoRegisterCluster.extraArgs - Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.
-  ##
   autoRegisterCluster:
-    enabled: false
-    resourceName: ""
-    extraArgs: ""
+    enabled: false # @schema; description: Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
+    resourceName: "" # @schema; description: Name of the StrongDM Pod Identity Cluster resource to create.
+    extraArgs: "" # @schema; description: Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.
 
   ## StrongDM authentication sources.
   ##
-  ## @param strongdm.auth.clusterKey - The SDM_PROXY_CLUSTER_ACCESS_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
-  ## @param strongdm.auth.clusterSecret - The SDM_PROXY_CLUSTER_SECRET_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
-  ## @param strongdm.auth.adminToken - The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
-  ## @param strongdm.auth.secretName - Name of the k8s Secret that contains SDM_PROXY_CLUSTER_ACCESS_KEY and SDM_PROXY_CLUSTER_SECRET_KEY, and/or SDM_ADMIN_TOKEN.
   auth:
-    clusterKey: ""
-    clusterSecret: ""
-    adminToken: ""
-    secretName: ""
+    clusterKey: "" # @schema; description: The SDM_PROXY_CLUSTER_ACCESS_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+    clusterSecret: "" # @schema; description: The SDM_PROXY_CLUSTER_SECRET_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+    adminToken: "" # @schema; description: The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+    secretName: "" # @schema; description: Name of the k8s Secret that contains SDM_PROXY_CLUSTER_ACCESS_KEY and SDM_PROXY_CLUSTER_SECRET_KEY, and/or SDM_ADMIN_TOKEN.
 
   ## Service configuration.
   ##
-  ## @param strongdm.service.annotations - Map of annotations to apply to the Service.
-  ## @param strongdm.service.labels - Map of labels to apply to the Service.
-  ## @param strongdm.service.type - Specify the type of Service to front the deployment.
-  ## @param strongdm.containerPort - Port on which the container runs.
-  ## @param strongdm.listenPort - Port on which the Service is expecting traffic.
-  ## @param strongdm.service.nodePort - NodePort to which to bind this service, if desired.
-  ## @param strongdm.service.loadBalancerIP - IP address to which to pin a LoadBalancer Service.
-  ##
   service:
-    annotations: {}
-    labels: {}
-    type: ClusterIP
-    listenPort: 443
-    containerPort: 8443
-    nodePort: 0
-    loadBalancerIP: ""
+    annotations: {} # @schema; description: Map of annotations to apply to the Service.
+    labels: {} # @schema; description: Map of labels to apply to the Service.
+    type: ClusterIP # @schema; description: Specify the type of Service to front the deployment.
+    listenPort: 443 # @schema; description: Port on which the container runs.
+    containerPort: 8443 # @schema; description: Port on which the Service is expecting traffic.
+    nodePort: 0 # @schema; description: NodePort to which to bind this service, if desired.
+    loadBalancerIP: "" # @schema; description: IP address to which to pin a LoadBalancer Service.
+    tlsSource: "" # @schema; description: How this service is expected to terminate TLS, if at all. Set to `file` and supply @strongdm.service.tlsSecretName to terminate with a user-provided certificate. Set to `none` if terminating TLS before these containers, e.g. with a load balancer. Leave empty to terminate TLS with a StrongDM-signed certificate built into the software.
+    tlsSecretName: "" # @schema; description: kubernetes.io/tls Secret with which containers will terminate TLS.
 
   ## Deployment configuration.
   ##
-  ## @param strongdm.deployment.annotations - Map of annotations to add to the Deployment.
-  ## @param strongdm.deployment.labels - Map of labels to add to the Deployment.
-  ## @param strongdm.compute.replicaCount - Number of Pods to run in the deployment.
-  ## @param strongdm.compute.topologySpreadConstraints - Pod spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.
   deployment:
-    annotations: {}
-    labels: {}
-    replicaCount: 2
-    topologySpreadConstraints:
+    annotations: {} # @schema; description: Map of annotations to add to the Deployment.
+    labels: {} # @schema; description: Map of labels to add to the Deployment.
+    replicaCount: 2 # @schema; description: Number of Pods to run in the deployment.
+    topologySpreadConstraints: # @schema; description: Pod spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.
       maxSkew: 1
       topologyKey: topology.kubernetes.io/zone
       whenUnsatisfiable: ScheduleAnyway
 
   ## Pod configuration.
   ##
-  ## @param strongdm.pod.annotations - Map of annotations to add to Pods.
-  ## @param strongdm.pod.labels - Map of labels to add to Pods.
-  ## @param strongdm.pod.resources - Set the Pod resource requests and limits.
   pod:
-    annotations: {}
-    labels: {}
-    resources:
+    annotations: {} # @schema; description: Map of annotations to add to Pods.
+    labels: {} # @schema; description: Map of labels to add to Pods.
+    resources: # @schema; description: Set the Pod resource requests and limits.
       requests:
         memory: 2560Mi
         cpu: 1024m
@@ -120,13 +84,8 @@ strongdm:
 
   ## Service account configuration.
   ##
-  ## @param strongdm.serviceAccount.create - Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.
-  ## @param strongdm.serviceAccount.name - Name of an existing ServiceAccount to use.
-  ## @param strongdm.serviceAccount.annotations - Map of annotations to add to the ServiceAccount, should one be created.
-  ## @param strongdm.serviceAccount.labels - Map of labels to add to the ServiceAccount, should one be created.
-  ##
   serviceAccount:
-    create: false
-    name: ""
-    annotations: {}
-    labels: {}
+    create: false # @schema; description: Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.
+    name: "" # @schema; description: Name of an existing ServiceAccount to use.
+    annotations: {} # @schema; description: Map of annotations to add to the ServiceAccount, should one be created.
+    labels: {} # @schema; description: Map of labels to add to the ServiceAccount, should one be created.


### PR DESCRIPTION
## Description of changes
The new values allow users more control over TLS setups. They include 
- `file` (along with `strongdm.service.tlsSecretName`) =  terminate with a user-provided certificate
- `none` = terminate TLS before these containers, e.g. with a load balancer
- default/empty = terminate TLS with a StrongDM-signed certificate built into the software

This PR also restrcutures the comments in `values.yaml` so that we generate descriptions in the values schema. This feels like a good practice and is used by some other well-known charts (thinking of you, Bitnami). It admittedly makes `values.yaml` a bit harder to parse, but not terribly so. Open to opinions here, though.

Introducing a pattern for creating dev Chart versions here, with the tag `v1.0.7-pre1`. Users will not pull these versions by default, they must explicitly `helm install --devel` or `helm install --version='>0.0.0-0'`.

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [ ] (optionally) deployed this change to k8s cluster.
