### PR TITLE
quieter default log config

### DIFF
--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 1.0.7-pre1
+version: 1.0.7-pre2
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 1.0.7-pre2
+version: 1.1.0-pre1
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/configmap.yaml
+++ b/deployments/sdm-proxy/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
   SDM_DISABLE_UPDATE: {{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
   SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
   SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs }}
+  SDM_DOCKERIZED: {{ eq .Values.strongdm.config.queryLogs.storage "stdout" | ternary "stderr" "" }}
   SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.queryLogs.format }}
   SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.queryLogs.storage }}
   SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.queryLogs.encryption }}

--- a/deployments/sdm-proxy/templates/configmap.yaml
+++ b/deployments/sdm-proxy/templates/configmap.yaml
@@ -15,9 +15,10 @@ data:
   SDM_DOMAIN: {{ .Values.strongdm.config.domain }}
   SDM_DISABLE_UPDATE: {{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
   SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
-  SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.logOptions.format }}
-  SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.logOptions.storage }}
-  SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.logOptions.encryption }}
+  SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs }}
+  SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.queryLogs.format }}
+  SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.queryLogs.storage }}
+  SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.queryLogs.encryption }}
   SDM_ORCHESTRATOR_PROBES: :9090
   SDM_METRICS_LISTEN_ADDRESS: {{ .Values.strongdm.config.enableMetrics | ternary ":9999" "" }}
   SDM_TLS_CERT_SOURCE: {{ .Values.strongdm.service.tlsSource }}

--- a/deployments/sdm-proxy/templates/configmap.yaml
+++ b/deployments/sdm-proxy/templates/configmap.yaml
@@ -15,8 +15,8 @@ data:
   SDM_DOMAIN: {{ .Values.strongdm.config.domain }}
   SDM_DISABLE_UPDATE: {{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
   SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
-  SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs }}
-  SDM_DOCKERIZED: {{ eq .Values.strongdm.config.queryLogs.storage "stdout" | ternary "stderr" "" }}
+  SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs | quote }}
+  SDM_DOCKERIZED: {{ eq .Values.strongdm.config.queryLogs.storage "stdout" | ternary "stderr" "true" }}
   SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.queryLogs.format }}
   SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.queryLogs.storage }}
   SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.queryLogs.encryption }}

--- a/deployments/sdm-proxy/values.schema.json
+++ b/deployments/sdm-proxy/values.schema.json
@@ -82,6 +82,7 @@
                             "type": "integer"
                         },
                         "queryLogs": {
+                            "description": "Query logging options, disabled by default. See https://www.strongdm.com/docs/admin/logs for more information.",
                             "properties": {
                                 "encoding": {
                                     "description": "Query log encoding",

--- a/deployments/sdm-proxy/values.schema.json
+++ b/deployments/sdm-proxy/values.schema.json
@@ -23,6 +23,7 @@
         "strongdm": {
             "properties": {
                 "auth": {
+                    "description": "StrongDM authentication sources.",
                     "properties": {
                         "adminToken": {
                             "description": "The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.",
@@ -44,6 +45,7 @@
                     "type": "object"
                 },
                 "autoRegisterCluster": {
+                    "description": "Cluster auto-registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.",
                     "properties": {
                         "enabled": {
                             "description": "Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.",
@@ -61,6 +63,7 @@
                     "type": "object"
                 },
                 "config": {
+                    "description": "General application configuration.",
                     "properties": {
                         "disableAutoUpdate": {
                             "description": "Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.",
@@ -74,29 +77,36 @@
                             "description": "Enable Prometheus metrics on port 9999.",
                             "type": "boolean"
                         },
-                        "logOptions": {
-                            "description": "Configuration for container logs.",
+                        "maintenanceWindowStart": {
+                            "description": "Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.",
+                            "type": "integer"
+                        },
+                        "queryLogs": {
                             "properties": {
-                                "encryption": {
+                                "encoding": {
+                                    "description": "Query log encoding",
                                     "type": "string"
                                 },
                                 "format": {
+                                    "description": "Query log format",
                                     "type": "string"
                                 },
                                 "storage": {
+                                    "description": "Query log storage location",
                                     "type": "string"
                                 }
                             },
                             "type": "object"
                         },
-                        "maintenanceWindowStart": {
-                            "description": "Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.",
-                            "type": "integer"
+                        "verboseLogs": {
+                            "description": "Toggle debug logging.",
+                            "type": "boolean"
                         }
                     },
                     "type": "object"
                 },
                 "deployment": {
+                    "description": "Deployment configuration.",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to add to the Deployment.",
@@ -157,6 +167,7 @@
                     "type": "string"
                 },
                 "pod": {
+                    "description": "Pod configuration.",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to add to Pods.",
@@ -197,6 +208,7 @@
                     "type": "object"
                 },
                 "service": {
+                    "description": "Service configuration.",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to apply to the Service.",
@@ -240,6 +252,7 @@
                     "type": "object"
                 },
                 "serviceAccount": {
+                    "description": "ServiceAccount configuration.",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to add to the ServiceAccount, should one be created.",

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -19,7 +19,7 @@ strongdm:
     maintenanceWindowStart: 0 # @schema; description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
     enableMetrics: false # @schema; description: Enable Prometheus metrics on port 9999.
     verboseLogs: false # @schema; description: Toggle debug logging.
-    queryLogs:
+    queryLogs: # @schema; description: Query logging options, disabled by default. See https://www.strongdm.com/docs/admin/logs for more information.
       storage: "" # @schema; description: Query log storage location; options: 'stdout', 'tcp', 'syslog', 'socket', 'file'. The default is to disable the additional audit logs.
       format: "" # @schema; description: Query log format; options: 'json', 'csv'.
       encoding: "" # @schema; description: Query log encoding; options: 'plaintext', 'publickey'

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -1,54 +1,41 @@
 global:
-  ## Metadata applied to all resources.
-  ##
   addDateLabel: true # @schema; description: Adds a `date: {{ now | htmlDate }}` label to all resources.
   annotations: {} # @schema; description: Map of annotations to add to all resources.
   labels: {} # @schema; description: Map of labels to add to all resources.
 
 strongdm:
-  ## Allow some overrides. Useful when installing as a subchart.
-  ##
   nameOverride: "" # @schema; description: Override resource names.
   namespaceOverride: "" # @schema; description: Override the release namespace.
 
-  ## Image pull configuration.
-  ##
   image: # @schema; description: Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
     pullPolicy: IfNotPresent
     repository: public.ecr.aws/strongdm/relay
     tag: latest
     digest: ""
 
-  ## General configuration.
-  ##
-  config:
+  config: # @schema; description: General application configuration.
     domain: strongdm.com # @schema; description: Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
     disableAutoUpdate: false # @schema; description: Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
     maintenanceWindowStart: 0 # @schema; description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
     enableMetrics: false # @schema; description: Enable Prometheus metrics on port 9999.
-    logOptions: # @schema; description: Configuration for container logs.
-      format: json
-      storage: stdout
-      encryption: plaintext
+    verboseLogs: false # @schema; description: Toggle debug logging.
+    queryLogs:
+      storage: "" # @schema; description: Query log storage location; options: 'stdout', 'tcp', 'syslog', 'socket', 'file'. The default is to disable the additional audit logs.
+      format: "" # @schema; description: Query log format; options: 'json', 'csv'.
+      encoding: "" # @schema; description: Query log encoding; options: 'plaintext', 'publickey'
 
-  ## Auto registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
-  ##
-  autoRegisterCluster:
+  autoRegisterCluster: # @schema; description: Cluster auto-registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
     enabled: false # @schema; description: Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
     resourceName: "" # @schema; description: Name of the StrongDM Pod Identity Cluster resource to create.
     extraArgs: "" # @schema; description: Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.
 
-  ## StrongDM authentication sources.
-  ##
-  auth:
+  auth: # @schema; description: StrongDM authentication sources.
     clusterKey: "" # @schema; description: The SDM_PROXY_CLUSTER_ACCESS_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
     clusterSecret: "" # @schema; description: The SDM_PROXY_CLUSTER_SECRET_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
     adminToken: "" # @schema; description: The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
     secretName: "" # @schema; description: Name of the k8s Secret that contains SDM_PROXY_CLUSTER_ACCESS_KEY and SDM_PROXY_CLUSTER_SECRET_KEY, and/or SDM_ADMIN_TOKEN.
 
-  ## Service configuration.
-  ##
-  service:
+  service: # @schema; description: Service configuration.
     annotations: {} # @schema; description: Map of annotations to apply to the Service.
     labels: {} # @schema; description: Map of labels to apply to the Service.
     type: ClusterIP # @schema; description: Specify the type of Service to front the deployment.
@@ -59,9 +46,7 @@ strongdm:
     tlsSource: "" # @schema; description: How this service is expected to terminate TLS, if at all. Set to `file` and supply @strongdm.service.tlsSecretName to terminate with a user-provided certificate. Set to `none` if terminating TLS before these containers, e.g. with a load balancer. Leave empty to terminate TLS with a StrongDM-signed certificate built into the software.
     tlsSecretName: "" # @schema; description: kubernetes.io/tls Secret with which containers will terminate TLS.
 
-  ## Deployment configuration.
-  ##
-  deployment:
+  deployment: # @schema; description: Deployment configuration.
     annotations: {} # @schema; description: Map of annotations to add to the Deployment.
     labels: {} # @schema; description: Map of labels to add to the Deployment.
     replicaCount: 2 # @schema; description: Number of Pods to run in the deployment.
@@ -70,9 +55,7 @@ strongdm:
       topologyKey: topology.kubernetes.io/zone
       whenUnsatisfiable: ScheduleAnyway
 
-  ## Pod configuration.
-  ##
-  pod:
+  pod: # @schema; description: Pod configuration.
     annotations: {} # @schema; description: Map of annotations to add to Pods.
     labels: {} # @schema; description: Map of labels to add to Pods.
     resources: # @schema; description: Set the Pod resource requests and limits.
@@ -82,9 +65,7 @@ strongdm:
       limits:
         memory: 2560Mi
 
-  ## Service account configuration.
-  ##
-  serviceAccount:
+  serviceAccount: # @schema; description: ServiceAccount configuration.
     create: false # @schema; description: Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.
     name: "" # @schema; description: Name of an existing ServiceAccount to use.
     annotations: {} # @schema; description: Map of annotations to add to the ServiceAccount, should one be created.

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 1.0.6
+version: 1.0.7-pre1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 1.0.7-pre1
+version: 1.1.0-pre1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/configmap.yaml
+++ b/deployments/sdm-relay/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
   SDM_DISABLE_UPDATE: {{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
   SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
   SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs }}
+  SDM_DOCKERIZED: {{ eq .Values.strongdm.config.queryLogs.storage "stdout" | ternary "stderr" "" }}
   SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.queryLogs.format }}
   SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.queryLogs.storage }}
   SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.queryLogs.encryption }}

--- a/deployments/sdm-relay/templates/configmap.yaml
+++ b/deployments/sdm-relay/templates/configmap.yaml
@@ -12,8 +12,8 @@ data:
   SDM_DOMAIN: {{ .Values.strongdm.config.domain }}
   SDM_DISABLE_UPDATE: {{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
   SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
-  SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs }}
-  SDM_DOCKERIZED: {{ eq .Values.strongdm.config.queryLogs.storage "stdout" | ternary "stderr" "" }}
+  SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs | quote }}
+  SDM_DOCKERIZED: {{ eq .Values.strongdm.config.queryLogs.storage "stdout" | ternary "stderr" "true" }}
   SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.queryLogs.format }}
   SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.queryLogs.storage }}
   SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.queryLogs.encryption }}

--- a/deployments/sdm-relay/templates/configmap.yaml
+++ b/deployments/sdm-relay/templates/configmap.yaml
@@ -12,8 +12,9 @@ data:
   SDM_DOMAIN: {{ .Values.strongdm.config.domain }}
   SDM_DISABLE_UPDATE: {{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
   SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
-  SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.logOptions.format }}
-  SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.logOptions.storage }}
-  SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.logOptions.encryption }}
+  SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs }}
+  SDM_RELAY_LOG_FORMAT: {{ .Values.strongdm.config.queryLogs.format }}
+  SDM_RELAY_LOG_STORAGE: {{ .Values.strongdm.config.queryLogs.storage }}
+  SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.queryLogs.encryption }}
   SDM_ORCHESTRATOR_PROBES: :9090
   SDM_METRICS_LISTEN_ADDRESS: {{ .Values.strongdm.config.enableMetrics | ternary ":9999" "" }}

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -100,6 +100,7 @@
                             "type": "integer"
                         },
                         "queryLogs": {
+                            "description": "Query logging options, disabled by default. See https://www.strongdm.com/docs/admin/logs for more information.",
                             "properties": {
                                 "encoding": {
                                     "description": "Query log encoding",

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -141,7 +141,7 @@
                     "type": "object"
                 },
                 "gateway": {
-                    "description": "StrongDM Gateway configuration.",
+                    "description": "StrongDM Gateway configuration. See https://www.strongdm.com/docs/admin/nodes for more information.",
                     "properties": {
                         "containerPort": {
                             "description": "Port on which the container runs.",

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -4,13 +4,16 @@
         "global": {
             "properties": {
                 "addDateLabel": {
+                    "description": "Adds a `date: {{ now | htmlDate }}` label to all resources.",
                     "type": "boolean"
                 },
                 "annotations": {
+                    "description": "Map of annotations to add to all resources.",
                     "properties": {},
                     "type": "object"
                 },
                 "labels": {
+                    "description": "Map of labels to add to all resources.",
                     "properties": {},
                     "type": "object"
                 }
@@ -20,88 +23,116 @@
         "strongdm": {
             "properties": {
                 "auth": {
+                    "description": "StrongDM authentication sources.",
                     "properties": {
                         "adminToken": {
+                            "description": "The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.",
                             "type": "string"
                         },
                         "relayToken": {
+                            "description": "The SDM_RELAY_TOKEN with which this relay should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.",
                             "type": "string"
                         },
                         "secretName": {
+                            "description": "Name of the k8s Secret that contains SDM_RELAY_TOKEN and/or SDM_ADMIN_TOKEN.",
                             "type": "string"
                         }
                     },
                     "type": "object"
                 },
                 "autoCreateNode": {
+                    "description": "Auto creation configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.",
                     "properties": {
                         "enabled": {
+                            "description": "Create this StrongDM Relay or Gateway automatically.",
                             "type": "boolean"
                         },
                         "maintenanceWindows": {
+                            "description": "Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6",
                             "type": "string"
                         },
                         "name": {
+                            "description": "Name of the Node as it should appear in StrongDM.",
                             "type": "string"
                         },
                         "tags": {
+                            "description": "Tags to add to the created Node. Format 'key=value,key2=value2'.",
                             "type": "string"
                         }
                     },
                     "type": "object"
                 },
                 "autoRegisterCluster": {
+                    "description": "Cluster auto-registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.",
                     "properties": {
                         "enabled": {
+                            "description": "Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.",
                             "type": "boolean"
                         },
                         "extraArgs": {
+                            "description": "Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.",
                             "type": "string"
                         },
                         "resourceName": {
+                            "description": "Name of the StrongDM Pod Identity Cluster resource to create.",
                             "type": "string"
                         }
                     },
                     "type": "object"
                 },
                 "config": {
+                    "description": "General application configuration.",
                     "properties": {
                         "disableAutoUpdate": {
+                            "description": "Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.",
                             "type": "boolean"
                         },
                         "domain": {
+                            "description": "Control plane domain to which to connect. Format `uk.strongdm.com`, etc.",
                             "type": "string"
                         },
                         "enableMetrics": {
+                            "description": "Enable Prometheus metrics on port 9999.",
                             "type": "boolean"
                         },
-                        "logOptions": {
+                        "maintenanceWindowStart": {
+                            "description": "Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.",
+                            "type": "integer"
+                        },
+                        "queryLogs": {
                             "properties": {
-                                "encryption": {
+                                "encoding": {
+                                    "description": "Query log encoding",
                                     "type": "string"
                                 },
                                 "format": {
+                                    "description": "Query log format",
                                     "type": "string"
                                 },
                                 "storage": {
+                                    "description": "Query log storage location",
                                     "type": "string"
                                 }
                             },
                             "type": "object"
                         },
-                        "maintenanceWindowStart": {
-                            "type": "integer"
+                        "verboseLogs": {
+                            "description": "Toggle debug logging.",
+                            "type": "boolean"
                         }
                     },
                     "type": "object"
                 },
                 "deployment": {
+                    "description": "Deployment configuration.",
                     "properties": {
                         "annotations": {
+                            "description": "Map of annotations to add to the Deployment.",
                             "properties": {},
                             "type": "object"
                         },
                         "labels": {
+                            "description": "Map of labels to add to the Deployment.",
                             "properties": {},
                             "type": "object"
                         }
@@ -109,36 +140,51 @@
                     "type": "object"
                 },
                 "gateway": {
+                    "description": "StrongDM Gateway configuration.",
                     "properties": {
                         "containerPort": {
+                            "description": "Port on which the container runs.",
                             "type": "integer"
                         },
                         "enabled": {
+                            "description": "Whether this is to be a StrongDM Gateway. If false, a Relay is created, and all other @strongdm.gateway values are ignored.",
                             "type": "boolean"
                         },
                         "listenAddress": {
+                            "description": "Address at which the Gateway expects traffic. Ignored unless @strongdm.autoCreateNode.enabled.",
                             "type": "string"
                         },
                         "listenPort": {
+                            "description": "Port on which the Service is expecting traffic.",
                             "type": "integer"
                         },
                         "service": {
+                            "description": "Service configuration. Ignored unless @strongdm.gateway.enabled.",
                             "properties": {
                                 "annotations": {
+                                    "description": "Map of annotations to apply to the Service.",
                                     "properties": {},
                                     "type": "object"
+                                },
+                                "containerPort": {
+                                    "description": "Port on which the Service is expecting traffic.",
+                                    "type": "integer"
                                 },
                                 "labels": {
+                                    "description": "Map of labels to apply to the Service.",
                                     "properties": {},
                                     "type": "object"
                                 },
-                                "loadBalancerIP": {
-                                    "type": "string"
+                                "listenPort": {
+                                    "description": "Port on which the container runs.",
+                                    "type": "integer"
                                 },
                                 "nodePort": {
+                                    "description": "NodePort to which to bind this service, if desired.",
                                     "type": "integer"
                                 },
                                 "type": {
+                                    "description": "Specify the type of Service to front the deployment.",
                                     "type": "string"
                                 }
                             },
@@ -148,6 +194,7 @@
                     "type": "object"
                 },
                 "image": {
+                    "description": "Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.",
                     "properties": {
                         "digest": {
                             "type": "string"
@@ -165,22 +212,28 @@
                     "type": "object"
                 },
                 "nameOverride": {
+                    "description": "Override resource names.",
                     "type": "string"
                 },
                 "namespaceOverride": {
+                    "description": "Override the release namespace.",
                     "type": "string"
                 },
                 "pod": {
+                    "description": "Pod configuration.",
                     "properties": {
                         "annotations": {
+                            "description": "Map of annotations to add to Pods.",
                             "properties": {},
                             "type": "object"
                         },
                         "labels": {
+                            "description": "Map of labels to add to Pods.",
                             "properties": {},
                             "type": "object"
                         },
                         "resources": {
+                            "description": "Set the Pod resource requests and limits.",
                             "properties": {
                                 "limits": {
                                     "properties": {
@@ -208,19 +261,24 @@
                     "type": "object"
                 },
                 "serviceAccount": {
+                    "description": "ServiceAccount configuration.",
                     "properties": {
                         "annotations": {
+                            "description": "Map of annotations to add to the ServiceAccount, should one be created.",
                             "properties": {},
                             "type": "object"
                         },
                         "create": {
+                            "description": "Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.",
                             "type": "boolean"
                         },
                         "labels": {
+                            "description": "Map of labels to add to the ServiceAccount, should one be created.",
                             "properties": {},
                             "type": "object"
                         },
                         "name": {
+                            "description": "Name of an existing ServiceAccount to use.",
                             "type": "string"
                         }
                     },

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -1,147 +1,74 @@
 global:
-  ## Metadata applied to all resources.
-  ##
-  ## @param global.addDateLabel - Adds a 'date: {{ now | htmlDate }}' label to all resources.
-  ## @param global.annotations - Map of annotations to add to all resources.
-  ## @param global.labels - Map of labels to add to all resources.
-  ##
-  addDateLabel: true
-  annotations: {}
-  labels: {}
+  addDateLabel: true # @schema; description: Adds a `date: {{ now | htmlDate }}` label to all resources.
+  annotations: {} # @schema; description: Map of annotations to add to all resources.
+  labels: {} # @schema; description: Map of labels to add to all resources.
 
 strongdm:
-  ## Allow some overrides. Useful when installing as a subchart.
-  ##
-  ## @param strongdm.nameOverride - Override resource names.
-  ## @param strongdm.namespaceOverride - Override the release namespace.
-  ##
-  nameOverride: ""
-  namespaceOverride: ""
+  nameOverride: "" # @schema; description: Override resource names.
+  namespaceOverride: "" # @schema; description: Override the release namespace.
 
-  ## Image pull configuration.
-  ##
-  ## @param strongdm.image - Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
-  ##
-  image:
+  image: # @schema; description: Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
     pullPolicy: IfNotPresent
     repository: public.ecr.aws/strongdm/relay
     tag: latest
     digest: ""
 
-  ## General configuration.
-  ##
-  ## @param strongdm.config.domain - Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
-  ## @param strongdm.config.disableAutoUpdate - Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
-  ## @param strongdm.config.maintenanceWindowStart - Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
-  ## @param strongdm.config.enableMetrics - Enable Prometheus metrics on port 9999.
-  ## @param strongdm.config.logOptions - Configuration for container logs.
-  ##
-  config:
-    domain: strongdm.com
-    disableAutoUpdate: false
-    maintenanceWindowStart: 0
-    enableMetrics: false
-    logOptions:
-      format: json
-      storage: stdout
-      encryption: plaintext
+  config: # @schema; description: General application configuration.
+    domain: strongdm.com # @schema; description: Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
+    disableAutoUpdate: false # @schema; description: Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
+    maintenanceWindowStart: 0 # @schema; description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
+    enableMetrics: false # @schema; description: Enable Prometheus metrics on port 9999.
+    verboseLogs: false # @schema; description: Toggle debug logging.
+    queryLogs:
+      storage: "" # @schema; description: Query log storage location; options: 'stdout', 'tcp', 'syslog', 'socket', 'file'. The default is to disable the additional audit logs.
+      format: "" # @schema; description: Query log format; options: 'json', 'csv'.
+      encoding: "" # @schema; description: Query log encoding; options: 'plaintext', 'publickey'
 
-  ## Auto registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
-  ##
-  ## @param strongdm.autoRegisterCluster.enabled - Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
-  ## @param strongdm.autoRegisterCluster.resourceName - Name of the StrongDM Pod Identity Cluster resource to create.
-  ## @param strongdm.autoRegisterCluster.extraArgs - Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.
-  ##
-  autoRegisterCluster:
-    enabled: false
-    resourceName: ""
-    extraArgs: ""
+  autoRegisterCluster: # @schema; description: Cluster auto-registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
+    enabled: false # @schema; description: Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
+    resourceName: "" # @schema; description: Name of the StrongDM Pod Identity Cluster resource to create.
+    extraArgs: "" # @schema; description: Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.
 
-  ## Auto creation configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
-  ##
-  ## @param strongdm.autoCreateNode.enabled - Create this StrongDM Relay or Gateway automatically.
-  ## @param strongdm.autoCreateNode.name - Name of the Node as it should appear in StrongDM.
-  ## @param strongdm.autoCreateNode.tags - Tags to add to the created Node. Format 'key=value,key2=value2'.
-  ## @param strongdm.autoCreateNode.maintenanceWindows - Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6;* * * * *'.
-  ##
-  autoCreateNode:
-    enabled: true
-    name: ""
-    tags: ""
-    maintenanceWindows: '* * * * *'
+  autoCreateNode: # @schema; description: Auto creation configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
+    enabled: true # @schema; description: Create this StrongDM Relay or Gateway automatically.
+    name: "" # @schema; description: Name of the Node as it should appear in StrongDM.
+    tags: "" # @schema; description: Tags to add to the created Node. Format 'key=value,key2=value2'.
+    maintenanceWindows: '* * * * *' # @schema; description: Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6;* * * * *'.
 
-  ## StrongDM authentication sources.
-  ##
-  ## @param strongdm.auth.relayToken - The SDM_RELAY_TOKEN with which this relay should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
-  ## @param strongdm.auth.adminToken - The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
-  ## @param strongdm.auth.secretName - Name of the k8s Secret that contains SDM_RELAY_TOKEN and/or SDM_ADMIN_TOKEN.
-  ##
-  auth:
-    relayToken: ""
-    adminToken: ""
-    secretName: ""
+  auth: # @schema; description: StrongDM authentication sources.
+    relayToken: "" # @schema; description: The SDM_RELAY_TOKEN with which this relay should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+    adminToken: "" # @schema; description: The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+    secretName: "" # @schema; description: Name of the k8s Secret that contains SDM_RELAY_TOKEN and/or SDM_ADMIN_TOKEN.
 
-  ## Gateway configuration.
-  ##
-  ## @param strongdm.gateway.enabled - Whether this is to be a StrongDM Gateway. If false, a Relay is created, and all other @strongdm.gateway values are ignored.
-  ## @param strongdm.gateway.listenAddress - Address at which the Gateway expects traffic. Ignored unless @strongdm.autoCreateNode.enabled.
-  ## @param strongdm.gateway.listenPort - Port on which the Service is expecting traffic.
-  ## @param strongdm.gateway.containerPort - Port on which the container runs.
-  ##
-  gateway:
-    enabled: false
-    listenAddress: ""
-    listenPort: 5000
-    containerPort: 5000
+  gateway: # @schema; description: StrongDM Gateway configuration.
+    enabled: false # @schema; description: Whether this is to be a StrongDM Gateway. If false, a Relay is created, and all other @strongdm.gateway values are ignored.
+    listenAddress: "" # @schema; description: Address at which the Gateway expects traffic. Ignored unless @strongdm.autoCreateNode.enabled.
+    listenPort: 5000 # @schema; description: Port on which the Service is expecting traffic.
+    containerPort: 5000 # @schema; description: Port on which the container runs.
+    service: # @schema; description: Service configuration. Ignored unless @strongdm.gateway.enabled.
+      annotations: {} # @schema; description: Map of annotations to apply to the Service.
+      labels: {} # @schema; description: Map of labels to apply to the Service.
+      type: ClusterIP # @schema; description: Specify the type of Service to front the deployment.
+      listenPort: 443 # @schema; description: Port on which the container runs.
+      containerPort: 8443 # @schema; description: Port on which the Service is expecting traffic.
+      nodePort: 0 # @schema; description: NodePort to which to bind this service, if desired.
 
-    ## Service configuration. Ignored unless @strongdm.gateway.enabled.
-    ##
-    ## @param strongdm.gateway.service.annotations - Map of annotations to apply to the Service.
-    ## @param strongdm.gateway.service.labels - Map of labels to apply to the Service.
-    ## @param strongdm.gateway.service.type - Specify the type of Service to front the deployment.
-    ## @param strongdm.gateway.service.nodePort - NodePort to which to bind this service, if desired.
-    ## @param strongdm.gateway.service.loadBalancerIP - IP address to which to pin a LoadBalancer Service.
-    ##
-    service:
-      annotations: {}
-      labels: {}
-      type: ClusterIP
-      nodePort: 0
-      loadBalancerIP: ""
+  deployment: # @schema; description: Deployment configuration.
+    annotations: {} # @schema; description: Map of annotations to add to the Deployment.
+    labels: {} # @schema; description: Map of labels to add to the Deployment.
 
-  ## Deployment configuration.
-  ##
-  ## @param strongdm.deployment.annotations - Map of annotations to add to the Deployment.
-  ## @param strongdm.deployment.labels - Map of labels to add to the Deployment.
-  deployment:
-    annotations: {}
-    labels: {}
-
-  ## Pod configuration.
-  ##
-  ## @param strongdm.pod.annotations - Map of annotations to add to Pods.
-  ## @param strongdm.pod.labels - Map of labels to add to Pods.
-  ## @param strongdm.pod.resources - Set the Pod resource requests and limits.
-  pod:
-    annotations: {}
-    labels: {}
-    resources:
+  pod: # @schema; description: Pod configuration.
+    annotations: {} # @schema; description: Map of annotations to add to Pods.
+    labels: {} # @schema; description: Map of labels to add to Pods.
+    resources: # @schema; description: Set the Pod resource requests and limits.
       requests:
         memory: 2560Mi
         cpu: 1024m
       limits:
         memory: 2560Mi
 
-  ## Service account configuration.
-  ##
-  ## @param strongdm.serviceAccount.create - Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount, falling back to the default ServiceAccount for that namespace.
-
-  ## @param strongdm.serviceAccount.name - Name of an existing ServiceAccount to use.
-  ## @param strongdm.serviceAccount.annotations - Map of annotations to add to the ServiceAccount, should one be created.
-  ## @param strongdm.serviceAccount.labels - Map of labels to add to the ServiceAccount, should one be created.
-  ##
-  serviceAccount:
-    create: false
-    name: ""
-    annotations: {}
-    labels: {}
+  serviceAccount: # @schema; description: ServiceAccount configuration.
+    create: false # @schema; description: Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.
+    name: "" # @schema; description: Name of an existing ServiceAccount to use.
+    annotations: {} # @schema; description: Map of annotations to add to the ServiceAccount, should one be created.
+    labels: {} # @schema; description: Map of labels to add to the ServiceAccount, should one be created.

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -19,8 +19,8 @@ strongdm:
     maintenanceWindowStart: 0 # @schema; description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
     enableMetrics: false # @schema; description: Enable Prometheus metrics on port 9999.
     verboseLogs: false # @schema; description: Toggle debug logging.
-    queryLogs:
-      storage: "" # @schema; description: Query log storage location; options: 'stdout', 'tcp', 'syslog', 'socket', 'file'. The default is to disable the additional audit logs.
+    queryLogs: # @schema; description: Query logging options, disabled by default. See https://www.strongdm.com/docs/admin/logs for more information.
+      storage: "" # @schema; description: Query log storage location; options: 'stdout', 'tcp', 'syslog', 'socket', 'file'.
       format: "" # @schema; description: Query log format; options: 'json', 'csv'.
       encoding: "" # @schema; description: Query log encoding; options: 'plaintext', 'publickey'
 

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -40,7 +40,7 @@ strongdm:
     adminToken: "" # @schema; description: The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
     secretName: "" # @schema; description: Name of the k8s Secret that contains SDM_RELAY_TOKEN and/or SDM_ADMIN_TOKEN.
 
-  gateway: # @schema; description: StrongDM Gateway configuration.
+  gateway: # @schema; description: StrongDM Gateway configuration. See https://www.strongdm.com/docs/admin/nodes for more information.
     enabled: false # @schema; description: Whether this is to be a StrongDM Gateway. If false, a Relay is created, and all other @strongdm.gateway values are ignored.
     listenAddress: "" # @schema; description: Address at which the Gateway expects traffic. Ignored unless @strongdm.autoCreateNode.enabled.
     listenPort: 5000 # @schema; description: Port on which the Service is expecting traffic.


### PR DESCRIPTION
## Description of changes
- The default log `storage=stdout` + `format=json` is _very_ noisy. This change defaults the chart to whatever the code defaults to, which feels reasonable.
- also name the values in a way that calls out they specifically configure the optional query logging, not the normal container logs.
- Also add support for debug logs.
- Was able to validate the changes in #38, cutting one more dev version to fully validate these logging updates.
- Make same values schema changes to `sdm-relay` chart.

I realize that changing values has user impacts, I hope for this to be the last such change for a little while. In an abundance of caution, though, I am calling for a minor version upgrade rather than a patch.

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [x] (optionally) deployed this change to k8s cluster (manually edited the `ConfigMap`)
