### PR TITLE
allow additional selectorLabels for services

### DIFF
--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 1.1.0
+version: 1.2.0-pre1
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -38,6 +38,9 @@ date: {{ now | htmlDate }}
 {{- define "strongdm.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/component: proxy
+{{- range $k, $v := .Values.strongdm.service.selectorLabels }}
+{{ $k }}: {{ $v | quote }}
+{{- end }}
 {{- end }}
 
 # Args:

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -37,6 +37,7 @@ date: {{ now | htmlDate }}
 
 {{- define "strongdm.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: proxy
 {{- range $k, $v := .Values.strongdm.service.selectorLabels }}
 {{ $k }}: {{ $v | quote }}

--- a/deployments/sdm-proxy/templates/configmap.yaml
+++ b/deployments/sdm-proxy/templates/configmap.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     {{- include "strongdm.labels" . | nindent 4 }}
 data:
-  SDM_DOMAIN: {{ .Values.strongdm.config.domain }}
+  SDM_APP_DOMAIN: {{ .Values.strongdm.config.appDomain | default (printf "app.%s" .Values.strongdm.config.domain) }}
   SDM_DISABLE_UPDATE: {{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
   SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
   SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs | quote }}

--- a/deployments/sdm-proxy/values.schema.json
+++ b/deployments/sdm-proxy/values.schema.json
@@ -65,12 +65,16 @@
                 "config": {
                     "description": "General application configuration.",
                     "properties": {
+                        "appDomain": {
+                            "description": "Control plane to which to connect. Format `uk.strongdm.com`, etc.",
+                            "type": "string"
+                        },
                         "disableAutoUpdate": {
                             "description": "Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.",
                             "type": "boolean"
                         },
                         "domain": {
-                            "description": "Control plane domain to which to connect. Format `uk.strongdm.com`, etc.",
+                            "description": "(DEPRECATED) control plane to which to connect. Format `uk.strongdm.com`, etc.",
                             "type": "string"
                         },
                         "enableMetrics": {
@@ -236,6 +240,11 @@
                         "nodePort": {
                             "description": "NodePort to which to bind this service, if desired.",
                             "type": "integer"
+                        },
+                        "selectorLabels": {
+                            "description": "Map of additional selector labels to apply to Pods and the Service.",
+                            "properties": {},
+                            "type": "object"
                         },
                         "tlsSecretName": {
                             "description": "kubernetes.io/tls Secret with which containers will terminate TLS.",

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -14,7 +14,8 @@ strongdm:
     digest: ""
 
   config: # @schema; description: General application configuration.
-    domain: strongdm.com # @schema; description: Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
+    domain: strongdm.com # @schema; description: (DEPRECATED) control plane to which to connect. Format `uk.strongdm.com`, etc.
+    appDomain: app.strongdm.com # @schema; description: Control plane to which to connect. Format `uk.strongdm.com`, etc.
     disableAutoUpdate: false # @schema; description: Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
     maintenanceWindowStart: 0 # @schema; description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
     enableMetrics: false # @schema; description: Enable Prometheus metrics on port 9999.
@@ -38,6 +39,7 @@ strongdm:
   service: # @schema; description: Service configuration.
     annotations: {} # @schema; description: Map of annotations to apply to the Service.
     labels: {} # @schema; description: Map of labels to apply to the Service.
+    selectorLabels: {} # @schema; description: Map of additional selector labels to apply to Pods and the Service.
     type: ClusterIP # @schema; description: Specify the type of Service to front the deployment.
     listenPort: 443 # @schema; description: Port on which the container runs.
     containerPort: 8443 # @schema; description: Port on which the Service is expecting traffic.

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 1.1.0
+version: 1.2.0-pre1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -42,6 +42,9 @@ date: {{ now | htmlDate }}
 {{- define "strongdm.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Chart.Name }}
 {{ include "strongdm.componentLabel" . }}
+{{- range $k, $v := .Values.strongdm.gateway.service.selectorLabels }}
+{{ $k }}: {{ $v | quote }}
+{{- end }}
 {{- end }}
 
 # Args:

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -41,6 +41,7 @@ date: {{ now | htmlDate }}
 
 {{- define "strongdm.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "strongdm.componentLabel" . }}
 {{- range $k, $v := .Values.strongdm.gateway.service.selectorLabels }}
 {{ $k }}: {{ $v | quote }}

--- a/deployments/sdm-relay/templates/configmap.yaml
+++ b/deployments/sdm-relay/templates/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     {{- include "strongdm.labels" . | nindent 4 }}
 data:
-  SDM_DOMAIN: {{ .Values.strongdm.config.domain }}
+  SDM_APP_DOMAIN: {{ .Values.strongdm.config.appDomain | default (printf "app.%s" .Values.strongdm.config.domain) }}
   SDM_DISABLE_UPDATE: {{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
   SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
   SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs | quote }}

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -83,12 +83,16 @@
                 "config": {
                     "description": "General application configuration.",
                     "properties": {
+                        "appDomain": {
+                            "description": "Control plane to which to connect. Format `uk.strongdm.com`, etc.",
+                            "type": "string"
+                        },
                         "disableAutoUpdate": {
                             "description": "Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.",
                             "type": "boolean"
                         },
                         "domain": {
-                            "description": "Control plane domain to which to connect. Format `uk.strongdm.com`, etc.",
+                            "description": "(DEPRECATED) control plane to which to connect. Format `uk.strongdm.com`, etc.",
                             "type": "string"
                         },
                         "enableMetrics": {
@@ -183,6 +187,11 @@
                                 "nodePort": {
                                     "description": "NodePort to which to bind this service, if desired.",
                                     "type": "integer"
+                                },
+                                "selectorLabels": {
+                                    "description": "Map of additional selector labels to apply to Pods and the Service.",
+                                    "properties": {},
+                                    "type": "object"
                                 },
                                 "type": {
                                     "description": "Specify the type of Service to front the deployment.",

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -14,7 +14,8 @@ strongdm:
     digest: ""
 
   config: # @schema; description: General application configuration.
-    domain: strongdm.com # @schema; description: Control plane domain to which to connect. Format `uk.strongdm.com`, etc.
+    domain: strongdm.com # @schema; description: (DEPRECATED) control plane to which to connect. Format `uk.strongdm.com`, etc.
+    appDomain: app.strongdm.com # @schema; description: Control plane to which to connect. Format `uk.strongdm.com`, etc.
     disableAutoUpdate: false # @schema; description: Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
     maintenanceWindowStart: 0 # @schema; description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
     enableMetrics: false # @schema; description: Enable Prometheus metrics on port 9999.
@@ -48,6 +49,7 @@ strongdm:
     service: # @schema; description: Service configuration. Ignored unless @strongdm.gateway.enabled.
       annotations: {} # @schema; description: Map of annotations to apply to the Service.
       labels: {} # @schema; description: Map of labels to apply to the Service.
+      selectorLabels: {} # @schema; description: Map of additional selector labels to apply to Pods and the Service.
       type: ClusterIP # @schema; description: Specify the type of Service to front the deployment.
       listenPort: 443 # @schema; description: Port on which the container runs.
       containerPort: 8443 # @schema; description: Port on which the Service is expecting traffic.


### PR DESCRIPTION
## Description of changes
When running multiple nodes in the same k8s cluster + namespace that are connecting to _different_ SDM control planes, services are not properly load balancing to just the Pods in their own Helm release. They're selecting all Pods across all such releases.

Add a new default selector label `app.kubernetes.io/instance: {{ .Release.Name }}` that will uniquely identify Pods in a namespace. You cannot have two Helm releases with the same name in a single namespace.

Also allow for additional selector labels. Didn't want to just throw all the global labels into this, it felt reasonable to create a new value to allow for higher granularity.

Finally, deprecate `SDM_DOMAIN` in favor of `SDM_APP_DOMAIN`,

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [ ] (optionally) deployed this change to k8s cluster (will do so after the devel versions are published)
