### PR TITLE
this is unfortunately a breaking change

### DIFF
--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 1.2.0-pre1
+version: 2.0.0
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 1.2.0-pre1
+version: 2.0.0
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png


### PR DESCRIPTION
## Description of changes
selector labels are immutable, so this fix unfortunately introduces a breaking change. users will need to either 
- uninstall and re-install the chart
- manually delete the k8s deployment and run a `helm upgrade`

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [x] (optionally) deployed this change to k8s cluster.
