### PR TITLE
remove dupe labels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.6.1
+    rev: v0.7.0
     hooks:
     -   id: pre-commit-update
 
@@ -15,7 +15,7 @@ repos:
     -   id: trailing-whitespace
 
 -   repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.28
+    rev: v0.1.29
     hooks:
     -   id: helmlint
     -   id: shellcheck
@@ -84,7 +84,8 @@ repos:
         pass_filenames: false
     -   id: template-invalid-tls-proxy-failure
         name: Helm template | invalid TLS fail | proxy
-        entry: /bin/bash -c '! helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.test.yaml --set strongdm.service.tlsSource=file'
+        entry: /bin/bash -c '! helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.test.yaml
+          --set strongdm.service.tlsSource=file'
         language: system
         pass_filenames: false
 
@@ -92,25 +93,37 @@ repos:
     -   id: template-tag-pin-relay
         name: Helm template | tag pin | relay
         entry: >
-            bash -c '[[ "$(helm template deployments/sdm-relay -f deployments/sdm-relay/values.yaml -f deployments/sdm-relay/values.test.yaml --set strongdm.image.tag=100.10.0 | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")" == "true" ]]'
+          bash -c '[[ "$(helm template deployments/sdm-relay -f deployments/sdm-relay/values.yaml
+          -f deployments/sdm-relay/values.test.yaml --set strongdm.image.tag=100.10.0
+          | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")"
+          == "true" ]]'
         language: system
         pass_filenames: false
     -   id: template-tag-pin-proxy
         name: Helm template | tag pin | proxy
         entry: >
-            bash -c '[[ "$(helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml -f deployments/sdm-proxy/values.test.yaml --set strongdm.image.tag=100.10.0 | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")" == "true" ]]'
+          bash -c '[[ "$(helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml
+          -f deployments/sdm-proxy/values.test.yaml --set strongdm.image.tag=100.10.0
+          | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")"
+          == "true" ]]'
         language: system
         pass_filenames: false
     -   id: template-digest-pin-relay
         name: Helm template | digest pin | relay
         entry: >
-            bash -c '[[ "$(helm template deployments/sdm-relay -f deployments/sdm-relay/values.yaml -f deployments/sdm-relay/values.test.yaml --set strongdm.image.digest=aaa | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")" == "true" ]]'
+          bash -c '[[ "$(helm template deployments/sdm-relay -f deployments/sdm-relay/values.yaml
+          -f deployments/sdm-relay/values.test.yaml --set strongdm.image.digest=aaa
+          | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")"
+          == "true" ]]'
         language: system
         pass_filenames: false
     -   id: template-digest-pin-proxy
         name: Helm template | digest pin | proxy
         entry: >
-            bash -c '[[ "$(helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml -f deployments/sdm-proxy/values.test.yaml --set strongdm.image.digest=aaa | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")" == "true" ]]'
+          bash -c '[[ "$(helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.yaml
+          -f deployments/sdm-proxy/values.test.yaml --set strongdm.image.digest=aaa
+          | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")"
+          == "true" ]]'
         language: system
         pass_filenames: false
 

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.0.0
+version: 2.0.1
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -22,7 +22,6 @@
 {{ include "strongdm.selectorLabels" . }}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 helm.sh/release: {{ .Release.Name }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.global.addDateLabel }}
 date: {{ now | htmlDate }}

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.0.0
+version: 2.0.1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -26,7 +26,6 @@ app.kubernetes.io/component: {{ .Values.strongdm.gateway.enabled | ternary "gate
 {{ include "strongdm.selectorLabels" . }}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 helm.sh/release: {{ .Release.Name }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.global.addDateLabel }}
 date: {{ now | htmlDate }}


### PR DESCRIPTION
## Description of changes
address #43 and removes the duplicate `app.kubernetes.io/instance` labels

## Validation steps
- [X] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [X] visibly confirmed the dupe label is gone after a `helm template`
- [ ] (optionally) deployed this change to k8s cluster.
