### PR TITLE
add support for additional, arbitrary env vars to be added to the ConfigMap

### DIFF
--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.0.1
+version: 2.1.0
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/configmap.yaml
+++ b/deployments/sdm-proxy/templates/configmap.yaml
@@ -27,3 +27,6 @@ data:
   SDM_TLS_CERT_FILE: /etc/sdm/tls.crt
   SDM_TLS_KEY_FILE: /etc/sdm/tls.key
   {{- end }}
+  {{- range $k, $v := .Values.strongdm.config.additionalEnvVars }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}

--- a/deployments/sdm-proxy/values.schema.json
+++ b/deployments/sdm-proxy/values.schema.json
@@ -65,6 +65,11 @@
                 "config": {
                     "description": "General application configuration.",
                     "properties": {
+                        "additionalEnvVars": {
+                            "description": "Additional environment variables to add to the ConfigMap.",
+                            "properties": {},
+                            "type": "object"
+                        },
                         "appDomain": {
                             "description": "Control plane to which to connect. Format `uk.strongdm.com`, etc.",
                             "type": "string"

--- a/deployments/sdm-proxy/values.test.yaml
+++ b/deployments/sdm-proxy/values.test.yaml
@@ -11,3 +11,8 @@ strongdm:
     create: true
   autoRegisterCluster:
     enabled: true
+  config:
+    additionalEnvVars:
+      foo: bar
+      bar: 2
+      baz: false

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -24,6 +24,7 @@ strongdm:
       storage: "" # @schema; description: Query log storage location; options: 'stdout', 'tcp', 'syslog', 'socket', 'file'. The default is to disable the additional audit logs.
       format: "" # @schema; description: Query log format; options: 'json', 'csv'.
       encoding: "" # @schema; description: Query log encoding; options: 'plaintext', 'publickey'
+    additionalEnvVars: {} # @schema; description: Additional environment variables to add to the ConfigMap.
 
   autoRegisterCluster: # @schema; description: Cluster auto-registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
     enabled: false # @schema; description: Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.0.1
+version: 2.1.0
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/configmap.yaml
+++ b/deployments/sdm-relay/templates/configmap.yaml
@@ -19,3 +19,6 @@ data:
   SDM_RELAY_LOG_ENCRYPTION: {{ .Values.strongdm.config.queryLogs.encryption }}
   SDM_ORCHESTRATOR_PROBES: :9090
   SDM_METRICS_LISTEN_ADDRESS: {{ .Values.strongdm.config.enableMetrics | ternary ":9999" "" }}
+  {{- range $k, $v := .Values.strongdm.config.additionalEnvVars }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -22,6 +22,11 @@
         },
         "strongdm": {
             "properties": {
+                "additionalEnvVars": {
+                    "description": "Additional environment variables to add to the ConfigMap.",
+                    "properties": {},
+                    "type": "object"
+                },
                 "auth": {
                     "description": "StrongDM authentication sources.",
                     "properties": {

--- a/deployments/sdm-relay/values.test.yaml
+++ b/deployments/sdm-relay/values.test.yaml
@@ -9,3 +9,8 @@ strongdm:
     create: true
   autoRegisterCluster:
     enabled: true
+  config:
+    additionalEnvVars:
+      foo: bar
+      bar: 2
+      baz: false

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -24,6 +24,7 @@ strongdm:
       storage: "" # @schema; description: Query log storage location; options: 'stdout', 'tcp', 'syslog', 'socket', 'file'.
       format: "" # @schema; description: Query log format; options: 'json', 'csv'.
       encoding: "" # @schema; description: Query log encoding; options: 'plaintext', 'publickey'
+  additionalEnvVars: {} # @schema; description: Additional environment variables to add to the ConfigMap.
 
   autoRegisterCluster: # @schema; description: Cluster auto-registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
     enabled: false # @schema; description: Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.


### PR DESCRIPTION
## Description of changes
Addresses #48, allowing for arbitrary key-value pairs to be supplied as environment variables. add a few different data types to `values.test.yaml`.

Considering this a `minor` version bump because it adds new functionality, but happy to discuss if folks disagree.

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [ ] (optionally) deployed this change to k8s cluster.
