### PR TITLE
allow Pod scheduling configs

### DIFF
--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.1.0
+version: 2.2.0-pre1
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/deployment.yaml
+++ b/deployments/sdm-proxy/templates/deployment.yaml
@@ -32,11 +32,11 @@ spec:
       terminationGracePeriodSeconds: 10
       nodeSelectors:
         {{- with .Values.strongdm.deployment.nodeSelector }}
-        {{- toYaml . | nindent 2 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       tolerations:
         {{- with .Values.strongdm.deployment.tolerations }}
-        {{- toYaml . | nindent 2 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       topologySpreadConstraints:
         {{- range $k, $v := .Values.strongdm.deployment.topologySpreadConstraints }}

--- a/deployments/sdm-proxy/templates/deployment.yaml
+++ b/deployments/sdm-proxy/templates/deployment.yaml
@@ -30,17 +30,27 @@ spec:
       serviceAccountName: {{ .Values.strongdm.serviceAccount.create | ternary .Release.Name .Values.strongdm.serviceAccount.name }}
       {{- end }}
       terminationGracePeriodSeconds: 10
+      nodeSelectors:
+        {{- with .Values.strongdm.deployment.nodeSelector }}
+        {{- toYaml . | nindent 2 }}
+        {{- end }}
+      tolerations:
+        {{- with .Values.strongdm.deployment.tolerations }}
+        {{- toYaml . | nindent 2 }}
+        {{- end }}
       topologySpreadConstraints:
-        - maxSkew: {{ .Values.strongdm.deployment.topologySpreadConstraints.maxSkew }}
-          topologyKey: {{ .Values.strongdm.deployment.topologySpreadConstraints.topologyKey }}
-          whenUnsatisfiable: {{ .Values.strongdm.deployment.topologySpreadConstraints.whenUnsatisfiable }}
+        {{- range $k, $v := .Values.strongdm.deployment.topologySpreadConstraints }}
+        - topologyKey: {{ $k }}
+          maxSkew: {{ $v.maxSkew }}
+          whenUnsatisfiable: {{ $v.whenUnsatisfiable }}
           labelSelector:
             matchLabels:
-              {{- include "strongdm.selectorLabels" . | nindent 14 }}
-            {{- if semverCompare ">=1.27.0" .Capabilities.KubeVersion.Version }}
+              {{- include "strongdm.selectorLabels" $ | nindent 14 }}
+            {{- if semverCompare ">=1.27.0" $.Capabilities.KubeVersion.Version }}
             matchLabelKeys:
               - pod-template-hash
             {{- end }}
+        {{- end }}
       {{- if .Values.strongdm.service.tlsSecretName }}
       volumes:
         - name: {{ .Release.Name }}-tls

--- a/deployments/sdm-proxy/values.schema.json
+++ b/deployments/sdm-proxy/values.schema.json
@@ -128,21 +128,32 @@
                             "properties": {},
                             "type": "object"
                         },
+                        "nodeSelector": {
+                            "description": "Pod node selectors.",
+                            "properties": {},
+                            "type": "object"
+                        },
                         "replicaCount": {
                             "description": "Number of Pods to run in the deployment.",
                             "type": "integer"
                         },
+                        "tolerations": {
+                            "description": "Pod node tolerations.",
+                            "type": "array"
+                        },
                         "topologySpreadConstraints": {
-                            "description": "Pod spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.",
+                            "description": "Pod spread constraints. Keys in this map are topology keys. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.",
                             "properties": {
-                                "maxSkew": {
-                                    "type": "integer"
-                                },
-                                "topologyKey": {
-                                    "type": "string"
-                                },
-                                "whenUnsatisfiable": {
-                                    "type": "string"
+                                "kubernetes.io/hostname": {
+                                    "properties": {
+                                        "maxSkew": {
+                                            "type": "integer"
+                                        },
+                                        "whenUnsatisfiable": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             },
                             "type": "object"

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -53,10 +53,12 @@ strongdm:
     annotations: {} # @schema; description: Map of annotations to add to the Deployment.
     labels: {} # @schema; description: Map of labels to add to the Deployment.
     replicaCount: 2 # @schema; description: Number of Pods to run in the deployment.
-    topologySpreadConstraints: # @schema; description: Pod spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.
-      maxSkew: 1
-      topologyKey: topology.kubernetes.io/zone
-      whenUnsatisfiable: ScheduleAnyway
+    nodeSelector: {} # @schema; description: Pod node selectors.
+    tolerations: [] # @schema; description: Pod node tolerations.
+    topologySpreadConstraints: # @schema; description: Pod spread constraints. Keys in this map are topology keys. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.
+      kubernetes.io/hostname:
+        maxSkew: 1
+        whenUnsatisfiable: ScheduleAnyway
 
   pod: # @schema; description: Pod configuration.
     annotations: {} # @schema; description: Map of annotations to add to Pods.

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.2.1-pre1
+version: 2.2.0-pre1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.1.1
+version: 2.2.1-pre1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/deployment.yaml
+++ b/deployments/sdm-relay/templates/deployment.yaml
@@ -30,11 +30,11 @@ spec:
       terminationGracePeriodSeconds: 10
       nodeSelectors:
         {{- with .Values.strongdm.deployment.nodeSelector }}
-        {{- toYaml . | nindent 2 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       tolerations:
         {{- with .Values.strongdm.deployment.tolerations }}
-        {{- toYaml . | nindent 2 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       containers:
         - name: sdm

--- a/deployments/sdm-relay/templates/deployment.yaml
+++ b/deployments/sdm-relay/templates/deployment.yaml
@@ -28,6 +28,14 @@ spec:
       serviceAccountName: {{ .Values.strongdm.serviceAccount.create | ternary .Release.Name .Values.strongdm.serviceAccount.name }}
       {{- end }}
       terminationGracePeriodSeconds: 10
+      nodeSelectors:
+        {{- with .Values.strongdm.deployment.nodeSelector }}
+        {{- toYaml . | nindent 2 }}
+        {{- end }}
+      tolerations:
+        {{- with .Values.strongdm.deployment.tolerations }}
+        {{- toYaml . | nindent 2 }}
+        {{- end }}
       containers:
         - name: sdm
           image: {{ template "strongdm.imageURI" . }}

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -145,6 +145,15 @@
                             "description": "Map of labels to add to the Deployment.",
                             "properties": {},
                             "type": "object"
+                        },
+                        "nodeSelector": {
+                            "description": "Pod node selectors.",
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "tolerations": {
+                            "description": "Pod node tolerations.",
+                            "type": "array"
                         }
                     },
                     "type": "object"

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -59,6 +59,8 @@ strongdm:
   deployment: # @schema; description: Deployment configuration.
     annotations: {} # @schema; description: Map of annotations to add to the Deployment.
     labels: {} # @schema; description: Map of labels to add to the Deployment.
+    nodeSelector: {} # @schema; description: Pod node selectors.
+    tolerations: [] # @schema; description: Pod node tolerations.
 
   pod: # @schema; description: Pod configuration.
     annotations: {} # @schema; description: Map of annotations to add to Pods.


### PR DESCRIPTION
## Description of changes
Addresses #44, allows for proper scheduling rules to be applied to all Pods. Support multiple topology spread constraints as well.

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [ ] (optionally) deployed this change to k8s cluster (i'm doing this in the next PR)
