### PR TITLE
fix typo, cut non-dev version

### DIFF
--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.2.0-pre1
+version: 2.2.0
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/deployment.yaml
+++ b/deployments/sdm-proxy/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: {{ .Values.strongdm.serviceAccount.create | ternary .Release.Name .Values.strongdm.serviceAccount.name }}
       {{- end }}
       terminationGracePeriodSeconds: 10
-      nodeSelectors:
+      nodeSelector:
         {{- with .Values.strongdm.deployment.nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.2.0-pre1
+version: 2.2.0
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/deployment.yaml
+++ b/deployments/sdm-relay/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: {{ .Values.strongdm.serviceAccount.create | ternary .Release.Name .Values.strongdm.serviceAccount.name }}
       {{- end }}
       terminationGracePeriodSeconds: 10
-      nodeSelectors:
+      nodeSelector:
         {{- with .Values.strongdm.deployment.nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## Description of changes
Finalizes changes from #51 . fixes a typo from the previous commit.

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [x] (optionally) deployed this change to k8s cluster
