### PR TITLE
use the Docker Hub bitnami image because it's multi-platform

### DIFF
--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.2.0
+version: 2.3.0-pre1
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/deployment.yaml
+++ b/deployments/sdm-proxy/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       restartPolicy: Always
       {{- if or .Values.strongdm.serviceAccount.create .Values.strongdm.serviceAccount.name }}
-      serviceAccountName: {{ .Values.strongdm.serviceAccount.create | ternary .Release.Name .Values.strongdm.serviceAccount.name }}
+      serviceAccountName: {{ .Values.strongdm.serviceAccount.create | ternary (include "strongdm.name" .) .Values.strongdm.serviceAccount.name }}
       {{- end }}
       terminationGracePeriodSeconds: 10
       nodeSelector:
@@ -53,7 +53,7 @@ spec:
         {{- end }}
       {{- if .Values.strongdm.service.tlsSecretName }}
       volumes:
-        - name: {{ .Release.Name }}-tls
+        - name: tls
           secret:
             secretName: {{ .Values.strongdm.service.tlsSecretName }}
       {{- end }}
@@ -73,12 +73,12 @@ spec:
             - name: SDM_PROXY_CLUSTER_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ default (printf "%s-secrets" .Release.Name) .Values.strongdm.auth.secretName }}
+                  name: {{ default (printf "%s-secrets" (include "strongdm.name" .)) .Values.strongdm.auth.secretName }}
                   key: SDM_PROXY_CLUSTER_ACCESS_KEY
             - name: SDM_PROXY_CLUSTER_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ default (printf "%s-secrets" .Release.Name) .Values.strongdm.auth.secretName }}
+                  name: {{ default (printf "%s-secrets" (include "strongdm.name" .)) .Values.strongdm.auth.secretName }}
                   key: SDM_PROXY_CLUSTER_SECRET_KEY
           envFrom:
             - configMapRef:
@@ -97,7 +97,7 @@ spec:
             {{- end }}
           {{- if .Values.strongdm.service.tlsSecretName }}
           volumeMounts:
-            - name: {{ .Release.Name }}-tls
+            - name: tls
               mountPath: /etc/sdm
               readOnly: true
           {{- end }}

--- a/deployments/sdm-proxy/templates/post-install.yaml
+++ b/deployments/sdm-proxy/templates/post-install.yaml
@@ -42,7 +42,7 @@ spec:
             - name: SDM_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ default (printf "%s-secrets" .Release.Name) .Values.strongdm.auth.secretName }}
+                  name: {{ default (printf "%s-secrets" (include "strongdm.name" .)) .Values.strongdm.auth.secretName }}
                   key: SDM_ADMIN_TOKEN
           envFrom:
             - configMapRef:
@@ -55,5 +55,5 @@ spec:
               /sdm.linux admin clusters add k8spodidentity \
                 --certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 {{ .Values.strongdm.autoRegisterCluster.extraArgs }} \
-                {{ default (printf "%s-cluster-%s" .Release.Name (randAlpha 5)) .Values.strongdm.autoRegisterCluster.resourceName }}
+                {{ default (printf "%s-cluster-%s" (include "strongdm.name" .) (randAlpha 5)) .Values.strongdm.autoRegisterCluster.resourceName }}
 {{- end}}

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.2.0
+version: 2.2.1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.2.1
+version: 2.3.0-pre1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/deployment.yaml
+++ b/deployments/sdm-relay/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       restartPolicy: Always
       {{- if or .Values.strongdm.serviceAccount.create .Values.strongdm.serviceAccount.name }}
-      serviceAccountName: {{ .Values.strongdm.serviceAccount.create | ternary .Release.Name .Values.strongdm.serviceAccount.name }}
+      serviceAccountName: {{ .Values.strongdm.serviceAccount.create | ternary (include "strongdm.name" .) .Values.strongdm.serviceAccount.name }}
       {{- end }}
       terminationGracePeriodSeconds: 10
       nodeSelector:
@@ -52,10 +52,10 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: SDM_RELAY_TOKEN
-                  name: {{ .Values.strongdm.autoCreateNode.enabled | ternary (printf "%s-relay-token" .Release.Name) (default (printf "%s-secrets" .Release.Name) .Values.strongdm.auth.secretName) }}
+                  name: {{ .Values.strongdm.autoCreateNode.enabled | ternary (printf "%s-relay-token" ( include "strongdm.name" . )) (default (printf "%s-secrets" ( include "strongdm.name" . )) .Values.strongdm.auth.secretName) }}
           envFrom:
             - configMapRef:
-                name: {{ .Release.Name }}-config
+                name: {{ include "strongdm.name" . }}-config
           ports:
             - name: healthcheck
               containerPort: 9090

--- a/deployments/sdm-relay/templates/post-install.yaml
+++ b/deployments/sdm-relay/templates/post-install.yaml
@@ -42,7 +42,7 @@ spec:
             - name: SDM_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ default (printf "%s-secrets" .Release.Name) .Values.strongdm.auth.secretName }}
+                  name: {{ default (printf "%s-secrets" (include "strongdm.name" .)) .Values.strongdm.auth.secretName }}
                   key: SDM_ADMIN_TOKEN
           envFrom:
             - configMapRef:
@@ -55,5 +55,5 @@ spec:
               /sdm.linux admin clusters add k8spodidentity \
                 --certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 {{ .Values.strongdm.autoRegisterCluster.extraArgs }} \
-                {{ default (printf "%s-cluster-%s" .Release.Name (randAlpha 5)) .Values.strongdm.autoRegisterCluster.resourceName }}
+                {{ default (printf "%s-cluster-%s" (include "strongdm.name" .) (randAlpha 5)) .Values.strongdm.autoRegisterCluster.resourceName }}
 {{- end}}

--- a/deployments/sdm-relay/templates/post-install.yaml
+++ b/deployments/sdm-relay/templates/post-install.yaml
@@ -46,7 +46,7 @@ spec:
                   key: SDM_ADMIN_TOKEN
           envFrom:
             - configMapRef:
-                name: {{ .Release.Name }}-config
+                name: {{ include "strongdm.name" . }}-config
           command:
             - /bin/bash
             - -c

--- a/deployments/sdm-relay/templates/pre-install.yaml
+++ b/deployments/sdm-relay/templates/pre-install.yaml
@@ -143,5 +143,5 @@ spec:
           command:
             - /bin/bash
             - -c
-            - kubectl create secret generic {{ .Release.Name }}-relay-token --from-literal=$(cat /secrets/token) --namespace {{ include "strongdm.namespace" . }} --dry-run=client -o yaml | kubectl apply -f -
+            - kubectl create secret generic {{ include "strongdm.name" . }}-relay-token --from-literal=$(cat /secrets/token) --namespace {{ include "strongdm.namespace" . }} --dry-run=client -o yaml | kubectl apply -f -
 {{- end }}

--- a/deployments/sdm-relay/templates/pre-install.yaml
+++ b/deployments/sdm-relay/templates/pre-install.yaml
@@ -128,7 +128,7 @@ spec:
       containers:
         - name: kubectl
           {{- $kubeVersion := semver .Capabilities.KubeVersion.Version }}
-          image: public.ecr.aws/bitnami/kubectl:{{ $kubeVersion.Major }}.{{ $kubeVersion.Minor }}
+          image: bitnami/kubectl:{{ $kubeVersion.Major }}.{{ $kubeVersion.Minor }}
           imagePullPolicy: IfNotPresent
           resources:
             requests:


### PR DESCRIPTION
## Description of changes
Addresses #46 by using a multi-platform `kubectl` image for the post-install Hook. Importantly, because this only happens _after_ installation is successful, we should be at much less risk of being rate limited by Docker Hub. If it was pre-install, I could foresee some retry logic spamming the registry and getting throttled.

Move to the `strongdm.name` helper function so name overrides are properly referenced everywhere.

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [ ] (optionally) deployed this change to k8s cluster (will do after this PR is merged)
