### PR TITLE
Better error handling

### DIFF
--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.3.0
+version: 2.3.1
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -5,6 +5,10 @@
 {{- default .Release.Namespace .Values.strongdm.namespaceOverride }}
 {{- end }}
 
+{{- define "strongdm.appDomain" -}}
+{{- default (printf "app.%s" .Values.strongdm.config.domain) .Values.strongdm.config.appDomain }}
+{{- end }}
+
 # Args:
 # - addtl: (optional) map of annotations to add
 {{- define "strongdm.annotations" -}}

--- a/deployments/sdm-proxy/templates/configmap.yaml
+++ b/deployments/sdm-proxy/templates/configmap.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     {{- include "strongdm.labels" . | nindent 4 }}
 data:
-  SDM_APP_DOMAIN: {{ .Values.strongdm.config.appDomain | default (printf "app.%s" .Values.strongdm.config.domain) }}
+  SDM_APP_DOMAIN: {{ include "strongdm.appDomain" . }}
   SDM_DISABLE_UPDATE: {{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
   SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
   SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs | quote }}

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.3.0
+version: 2.3.1-pre1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.3.1-pre1
+version: 2.3.1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -5,6 +5,10 @@
 {{- default .Release.Namespace .Values.strongdm.namespaceOverride }}
 {{- end }}
 
+{{- define "strongdm.appDomain" -}}
+{{- default (printf "app.%s" .Values.strongdm.config.domain) .Values.strongdm.config.appDomain }}
+{{- end }}
+
 # Args:
 # - addtl: (optional) map of annotations to add
 {{- define "strongdm.annotations" -}}

--- a/deployments/sdm-relay/templates/configmap.yaml
+++ b/deployments/sdm-relay/templates/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     {{- include "strongdm.labels" . | nindent 4 }}
 data:
-  SDM_APP_DOMAIN: {{ .Values.strongdm.config.appDomain | default (printf "app.%s" .Values.strongdm.config.domain) }}
+  SDM_APP_DOMAIN: {{ include "strongdm.appDomain" . }}
   SDM_DISABLE_UPDATE: {{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
   SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
   SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs | quote }}

--- a/deployments/sdm-relay/templates/pre-install.yaml
+++ b/deployments/sdm-relay/templates/pre-install.yaml
@@ -121,15 +121,15 @@ spec:
               /sdm.linux login --admin-token="${SDM_ADMIN_TOKEN}"
             {{- $commonArgs := printf "--maintenance-windows %s --name %s --tags %s" (squote .Values.strongdm.autoCreateNode.maintenanceWindows) (squote .Values.strongdm.autoCreateNode.name) (squote .Values.strongdm.autoCreateNode.tags) }}
             {{- if .Values.strongdm.gateway.enabled }}
-              SDM_RELAY_TOKEN=$(/sdm.linux admin node create-gateway {{ $commonArgs }} {{ .Values.strongdm.gateway.listenAddress }}:{{ .Values.strongdm.gateway.listenPort }})"
+              SDM_RELAY_TOKEN="$(/sdm.linux admin node create-gateway {{ $commonArgs }} {{ .Values.strongdm.gateway.listenAddress }}:{{ .Values.strongdm.gateway.listenPort }})"
             {{- else }}
-              SDM_RELAY_TOKEN=$(/sdm.linux admin node create {{ $commonArgs }})"
+              SDM_RELAY_TOKEN="$(/sdm.linux admin node create {{ $commonArgs }})"
             {{- end }}
               if [[ ! grep -qE "^[[:graph:]]+[.][[:graph:]]+[.][[:graph:]]+$" <<< "${SDM_RELAY_TOKEN}" ]]; then
                 echo "Error creating node: ${SDM_RELAY_TOKEN}"
                 exit 3;
               fi
-              echo "${SDM_RELAY_TOKEN}" /secrets/token
+              echo "${SDM_RELAY_TOKEN}" > /secrets/token
       containers:
         - name: kubectl
           {{- $kubeVersion := semver .Capabilities.KubeVersion.Version }}
@@ -148,5 +148,6 @@ spec:
           command:
             - /bin/bash
             - -c
-            - kubectl create secret generic {{ include "strongdm.name" . }}-relay-token --from-literal=$(cat /secrets/token) --namespace {{ include "strongdm.namespace" . }} --dry-run=client -o yaml | kubectl apply -f -
+            - |
+              kubectl create secret generic {{ include "strongdm.name" . }}-relay-token --from-literal="$(cat /secrets/token)" --namespace {{ include "strongdm.namespace" . }} --dry-run=client -o yaml | kubectl apply -f -
 {{- end }}

--- a/deployments/sdm-relay/templates/pre-install.yaml
+++ b/deployments/sdm-relay/templates/pre-install.yaml
@@ -103,8 +103,8 @@ spec:
               mountPath: /secrets
           env:
             # Reference these directly because we don't yet have access to the created Secret nor ConfigMap
-            - name: SDM_DOMAIN
-              value: {{ .Values.strongdm.config.domain }}
+            - name: SDM_APP_DOMAIN
+              value: {{ .Values.strongdm.config.appDomain | default (printf "app.%s" .Values.strongdm.config.domain) }}
             - name: SDM_ADMIN_TOKEN
               {{- if .Values.strongdm.auth.secretName }}
               valueFrom:
@@ -118,6 +118,7 @@ spec:
             - /bin/bash
             - -c
             - |
+              set -e -o pipefail
               /sdm.linux login --admin-token="${SDM_ADMIN_TOKEN}"
             {{- $commonArgs := printf "--maintenance-windows %s --name %s --tags %s" (squote .Values.strongdm.autoCreateNode.maintenanceWindows) (squote .Values.strongdm.autoCreateNode.name) (squote .Values.strongdm.autoCreateNode.tags) }}
             {{- if .Values.strongdm.gateway.enabled }}
@@ -125,11 +126,11 @@ spec:
             {{- else }}
               SDM_RELAY_TOKEN="$(/sdm.linux admin node create {{ $commonArgs }})"
             {{- end }}
-              if [[ ! grep -qE "^[[:graph:]]+[.][[:graph:]]+[.][[:graph:]]+$" <<< "${SDM_RELAY_TOKEN}" ]]; then
-                echo "Error creating node: ${SDM_RELAY_TOKEN}"
-                exit 3;
+              if ! grep -qE "^[[:graph:]]+[.][[:graph:]]+[.][[:graph:]]+$" <<< "${SDM_RELAY_TOKEN}"; then
+                echo "${SDM_RELAY_TOKEN}"
+                exit 3
               fi
-              echo "${SDM_RELAY_TOKEN}" > /secrets/token
+              echo "SDM_RELAY_TOKEN=${SDM_RELAY_TOKEN}" > /secrets/token
       containers:
         - name: kubectl
           {{- $kubeVersion := semver .Capabilities.KubeVersion.Version }}

--- a/deployments/sdm-relay/templates/pre-install.yaml
+++ b/deployments/sdm-relay/templates/pre-install.yaml
@@ -104,7 +104,7 @@ spec:
           env:
             # Reference these directly because we don't yet have access to the created Secret nor ConfigMap
             - name: SDM_APP_DOMAIN
-              value: {{ .Values.strongdm.config.appDomain | default (printf "app.%s" .Values.strongdm.config.domain) }}
+              value: {{ include "strongdm.appDomain" . }}
             - name: SDM_ADMIN_TOKEN
               {{- if .Values.strongdm.auth.secretName }}
               valueFrom:

--- a/deployments/sdm-relay/templates/pre-install.yaml
+++ b/deployments/sdm-relay/templates/pre-install.yaml
@@ -121,10 +121,15 @@ spec:
               /sdm.linux login --admin-token="${SDM_ADMIN_TOKEN}"
             {{- $commonArgs := printf "--maintenance-windows %s --name %s --tags %s" (squote .Values.strongdm.autoCreateNode.maintenanceWindows) (squote .Values.strongdm.autoCreateNode.name) (squote .Values.strongdm.autoCreateNode.tags) }}
             {{- if .Values.strongdm.gateway.enabled }}
-              echo "SDM_RELAY_TOKEN=$(/sdm.linux admin node create-gateway {{ $commonArgs }} {{ .Values.strongdm.gateway.listenAddress }}:{{ .Values.strongdm.gateway.listenPort }})" > /secrets/token
+              SDM_RELAY_TOKEN=$(/sdm.linux admin node create-gateway {{ $commonArgs }} {{ .Values.strongdm.gateway.listenAddress }}:{{ .Values.strongdm.gateway.listenPort }})"
             {{- else }}
-              echo "SDM_RELAY_TOKEN=$(/sdm.linux admin node create {{ $commonArgs }})" > /secrets/token
+              SDM_RELAY_TOKEN=$(/sdm.linux admin node create {{ $commonArgs }})"
             {{- end }}
+              if [[ ! grep -qE "^[[:graph:]]+[.][[:graph:]]+[.][[:graph:]]+$" <<< "${SDM_RELAY_TOKEN}" ]]; then
+                echo "Error creating node: ${SDM_RELAY_TOKEN}"
+                exit 3;
+              fi
+              echo "${SDM_RELAY_TOKEN}" /secrets/token
       containers:
         - name: kubectl
           {{- $kubeVersion := semver .Capabilities.KubeVersion.Version }}


### PR DESCRIPTION
## Description of changes
addresses #47, we need some error checking around the returned value of `/sdm.linux admin node create`. this introduces a few things:
- check for a valid format of the generated `SDM_RELAY_TOKEN`
- add `set -e -o pipefail` for extra circuit breaking
- just to be safe, double-quote `$(cat /secrets/token)`

also update the `pre-install` Job's env vars to support `SDM_APP_DOMAIN`, which was updated in the ConfigMap in a previous change but missed here. moved this logic to a helper function so we don't make the same mistake again.

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [x] (optionally) deployed this change to k8s cluster

I accomplished the latter locally with 
```
~: helm install good-admin-token deployments/sdm-relay -f good.yaml
Thank you for installing sdm-relay....

~: cat good.yaml
strongdm:
  config:
    appDomain: app.snd.strongdm.com
  auth:
    adminToken: REDACTED_BUT_VALID
  autoCreateNode:
    enabled: true
```

And then a "bad" token to trigger the new circuit breaker
```
~: helm install bad-admin-token deployments/sdm-relay -f bad.yaml
Error: INSTALLATION FAILED: release bad-admin-token failed, and has been uninstalled due to atomic being set: failed pre-install: 1 error occurred:
	* job bad-admin-token-auto-create-node-khlsg failed: BackoffLimitExceeded

~: cat bad.yaml
strongdm:
  config:
    appDomain: app.snd.strongdm.com
  auth:
    adminToken: this.is.invalid
  autoCreateNode:
    enabled: true
```