### PR TITLE
remove a few svc/pod port values

### DIFF
--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.3.2
+version: 2.3.3-pre1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -170,7 +170,7 @@
                             "type": "string"
                         },
                         "listenPort": {
-                            "description": "Port on which the Service is expecting traffic.",
+                            "description": "Port on which the Gateway expects traffic.",
                             "type": "integer"
                         },
                         "service": {
@@ -181,25 +181,17 @@
                                     "properties": {},
                                     "type": "object"
                                 },
-                                "containerPort": {
-                                    "description": "Port on which the Service is expecting traffic.",
-                                    "type": "integer"
-                                },
                                 "labels": {
                                     "description": "Map of labels to apply to the Service.",
                                     "properties": {},
                                     "type": "object"
-                                },
-                                "listenPort": {
-                                    "description": "Port on which the container runs.",
-                                    "type": "integer"
                                 },
                                 "nodePort": {
                                     "description": "NodePort to which to bind this service, if desired.",
                                     "type": "integer"
                                 },
                                 "selectorLabels": {
-                                    "description": "Map of additional selector labels to apply to Pods and the Service.",
+                                    "description": "Service selector labels.",
                                     "properties": {},
                                     "type": "object"
                                 },

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -44,15 +44,13 @@ strongdm:
   gateway: # @schema; description: StrongDM Gateway configuration. See https://www.strongdm.com/docs/admin/nodes for more information.
     enabled: false # @schema; description: Whether this is to be a StrongDM Gateway. If false, a Relay is created, and all other @strongdm.gateway values are ignored.
     listenAddress: "" # @schema; description: Address at which the Gateway expects traffic. Ignored unless @strongdm.autoCreateNode.enabled.
-    listenPort: 5000 # @schema; description: Port on which the Service is expecting traffic.
+    listenPort: 5000 # @schema; description: Port on which the Gateway expects traffic.
     containerPort: 5000 # @schema; description: Port on which the container runs.
     service: # @schema; description: Service configuration. Ignored unless @strongdm.gateway.enabled.
       annotations: {} # @schema; description: Map of annotations to apply to the Service.
       labels: {} # @schema; description: Map of labels to apply to the Service.
-      selectorLabels: {} # @schema; description: Map of additional selector labels to apply to Pods and the Service.
+      selectorLabels: {} # @schema; description: Service selector labels.
       type: ClusterIP # @schema; description: Specify the type of Service to front the deployment.
-      listenPort: 443 # @schema; description: Port on which the container runs.
-      containerPort: 8443 # @schema; description: Port on which the Service is expecting traffic.
       nodePort: 0 # @schema; description: NodePort to which to bind this service, if desired.
 
   deployment: # @schema; description: Deployment configuration.


### PR DESCRIPTION
## Description of changes
these values are unused, and were actually a lingering copy-paste typo from the large refactor. will install into a k8s cluster and follow up with a PR to bump to `2.3.3`.

- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [ ] (optionally) deployed this change to k8s cluster.
