### PR TITLE
actually allow overridding our image repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,7 +128,7 @@ repos:
         pass_filenames: false
 
 -   repo: https://github.com/losisin/helm-values-schema-json
-    rev: v1.8.0
+    rev: v2.0.0
     hooks:
     -   id: helm-schema
         name: helm-schema | relay

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.3.2
+version: 2.3.3
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.3.3
+version: 2.3.3-pre1
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.3.3-pre1
+version: 2.3.3
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -62,8 +62,8 @@ resources:
 # - digest: (optional) image digest
 {{- define "strongdm.imageURI" -}}
 {{- if .Values.strongdm.image.digest -}}
-{{ printf "%s@sha256:%s" (default "public.ecr.aws/strongdm/relay" .repository) .Values.strongdm.image.digest }}
+{{ printf "%s@sha256:%s" .Values.strongdm.image.repository .Values.strongdm.image.digest }}
 {{- else -}}
-{{ printf "%s:%s" (default "public.ecr.aws/strongdm/relay" .repository) .Values.strongdm.image.tag }}
+{{ printf "%s:%s" .Values.strongdm.image.repository .Values.strongdm.image.tag }}
 {{- end -}}
 {{- end }}

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.3.4-pre1
+version: 2.3.4
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.3.3
+version: 2.3.4
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.3.4
+version: 2.3.4-pre1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -66,8 +66,8 @@ resources:
 # - digest: (optional) image digest
 {{- define "strongdm.imageURI" -}}
 {{- if .Values.strongdm.image.digest -}}
-{{ printf "%s@sha256:%s" (default "public.ecr.aws/strongdm/relay" .repository) .Values.strongdm.image.digest }}
+{{ printf "%s@sha256:%s" .Values.strongdm.image.repository .Values.strongdm.image.digest }}
 {{- else -}}
-{{ printf "%s:%s" (default "public.ecr.aws/strongdm/relay" .repository) .Values.strongdm.image.tag }}
+{{ printf "%s:%s" .Values.strongdm.image.repository .Values.strongdm.image.tag }}
 {{- end -}}
 {{- end }}

--- a/deployments/sdm-relay/templates/pre-install.yaml
+++ b/deployments/sdm-relay/templates/pre-install.yaml
@@ -134,7 +134,7 @@ spec:
       containers:
         - name: kubectl
           {{- $kubeVersion := semver .Capabilities.KubeVersion.Version }}
-          image: bitnami/kubectl:{{ $kubeVersion.Major }}.{{ $kubeVersion.Minor }}
+          image: {{ default (printf "bitnami/kubectl:%s.%s" $kubeVersion.Major $kubeVersion.Minor) .Values.strongdm.autoCreateNode.kubectlImage }}
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -43,6 +43,10 @@
                             "description": "Create this StrongDM Relay or Gateway automatically.",
                             "type": "boolean"
                         },
+                        "kubectlImage": {
+                            "description": "Full URI of the container with kubectl installed, used to create needed a k8s Secret. Defaults to a bitnami/kubectl image.\"",
+                            "type": "string"
+                        },
                         "maintenanceWindows": {
                             "description": "Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6",
                             "type": "string"

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -44,7 +44,7 @@
                             "type": "boolean"
                         },
                         "kubectlImage": {
-                            "description": "Full URI of the container with kubectl installed, used to create needed a k8s Secret. Defaults to a bitnami/kubectl image.\"",
+                            "description": "Full URI of the container with kubectl installed, used to create a k8s Secret. Defaults to a bitnami/kubectl image.",
                             "type": "string"
                         },
                         "maintenanceWindows": {

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -35,7 +35,7 @@ strongdm:
     name: "" # @schema; description: Name of the Node as it should appear in StrongDM.
     tags: "" # @schema; description: Tags to add to the created Node. Format 'key=value,key2=value2'.
     maintenanceWindows: '* * * * *' # @schema; description: Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6;* * * * *'.
-    kubectlImage: "" # @schema; description: Full URI of the container with kubectl installed, used to create needed a k8s Secret. Defaults to a bitnami/kubectl image."
+    kubectlImage: "" # @schema; description: Full URI of the container with kubectl installed, used to create a k8s Secret. Defaults to a bitnami/kubectl image.
 
   auth: # @schema; description: StrongDM authentication sources.
     relayToken: "" # @schema; description: The SDM_RELAY_TOKEN with which this relay should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -35,6 +35,7 @@ strongdm:
     name: "" # @schema; description: Name of the Node as it should appear in StrongDM.
     tags: "" # @schema; description: Tags to add to the created Node. Format 'key=value,key2=value2'.
     maintenanceWindows: '* * * * *' # @schema; description: Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6;* * * * *'.
+    kubectlImage: "" # @schema; description: Full URI of the container with kubectl installed, used to create needed a k8s Secret. Defaults to a bitnami/kubectl image."
 
   auth: # @schema; description: StrongDM authentication sources.
     relayToken: "" # @schema; description: The SDM_RELAY_TOKEN with which this relay should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.


### PR DESCRIPTION
 as well as the bitnami/kubectl image

## Description of changes
addresses #57. fixes logic to properly allow overriding the public ECR image registry. also adds the ability to override the `bitnami/kubectl` image used during the relay pre-install hook.

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [ ] (optionally) deployed this change to k8s cluster.
