### PR TITLE
increase readiness probe timeout

### DIFF
--- a/deployments/sdm-client/Chart.yaml
+++ b/deployments/sdm-client/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-client
 kubeVersion: '>= 1.16.0-0'
-version: 1.0.0
+version: 1.0.1
 description: StrongDM Client Container
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-client/templates/deployment.yaml
+++ b/deployments/sdm-client/templates/deployment.yaml
@@ -53,6 +53,7 @@ spec:
               command: ["/sdm.linux", "-v"]
           readinessProbe:
             initialDelaySeconds: 5
+            timeoutSeconds: 10
             exec:
               command: ["sdm", "status"]
           env:


### PR DESCRIPTION
## Description of changes
we're seeing that the default 1s is too fast for the command, which totally makes sense.

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
