### PR TITLE
default to creating the SA for the proxy chart

### DIFF
--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.4.0
+version: 2.5.0
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/values.schema.json
+++ b/deployments/sdm-proxy/values.schema.json
@@ -282,7 +282,7 @@
                             "type": "object"
                         },
                         "create": {
-                            "description": "Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.",
+                            "description": "Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not use a ServiceAccount.",
                             "type": "boolean"
                         },
                         "labels": {

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -70,7 +70,7 @@ strongdm:
         memory: 2560Mi
 
   serviceAccount: # @schema; description: ServiceAccount configuration.
-    create: false # @schema; description: Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not create a ServiceAccount.
+    create: true # @schema; description: Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not use a ServiceAccount.
     name: "" # @schema; description: Name of an existing ServiceAccount to use.
     annotations: {} # @schema; description: Map of annotations to add to the ServiceAccount, should one be created.
     labels: {} # @schema; description: Map of labels to add to the ServiceAccount, should one be created.


### PR DESCRIPTION
## Description of changes
missed this in the previous change. think it requires a minor version bump because it's changing the default resources that get created.

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
