### PR TITLE
Allow client updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,6 +120,15 @@ repos:
           == "true" ]]'
         language: system
         pass_filenames: false
+    -   id: template-tag-pin-client
+        name: Helm template | tag pin should disable SDM_DISABLE_UPDATE | client
+        entry: >
+          bash -c '[[ "$(helm template deployments/sdm-client -f deployments/sdm-client/values.test.yaml
+          --set strongdm.image.tag=100.10.0
+          | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")"
+          == "true" ]]'
+        language: system
+        pass_filenames: false
     -   id: template-digest-pin-relay
         name: Helm template | digest pin should disable SDM_DISABLE_UPDATE |
           relay
@@ -135,6 +144,16 @@ repos:
           proxy
         entry: >
           bash -c '[[ "$(helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.test.yaml
+          --set strongdm.image.digest=aaa
+          | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")"
+          == "true" ]]'
+        language: system
+        pass_filenames: false
+    -   id: template-digest-pin-client
+        name: Helm template | digest pin should disable SDM_DISABLE_UPDATE |
+          client
+        entry: >
+          bash -c '[[ "$(helm template deployments/sdm-client -f deployments/sdm-client/values.test.yaml
           --set strongdm.image.digest=aaa
           | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")"
           == "true" ]]'

--- a/deployments/sdm-client/Chart.yaml
+++ b/deployments/sdm-client/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-client
 kubeVersion: '>= 1.16.0-0'
-version: 1.0.2
+version: 1.1.0
 description: StrongDM Client Container
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-client/templates/configmap.yaml
+++ b/deployments/sdm-client/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
   SDM_APP_DOMAIN: {{ include "strongdm.appDomain" . }}
   SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs | quote }}
   SDM_DISABLE_UPDATE: {{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
+  SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
   {{- range $k, $v := .Values.strongdm.config.additionalEnvVars }}
   {{ $k }}: {{ $v | quote }}
   {{- end }}

--- a/deployments/sdm-client/templates/configmap.yaml
+++ b/deployments/sdm-client/templates/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   SDM_APP_DOMAIN: {{ include "strongdm.appDomain" . }}
   SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs | quote }}
-  SDM_DISABLE_UPDATE: "true"
+  SDM_DISABLE_UPDATE: {{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
   {{- range $k, $v := .Values.strongdm.config.additionalEnvVars }}
   {{ $k }}: {{ $v | quote }}
   {{- end }}

--- a/deployments/sdm-client/values.schema.json
+++ b/deployments/sdm-client/values.schema.json
@@ -44,6 +44,14 @@
                             "description": "Control plane to which to connect. Format `uk.strongdm.com`, etc.",
                             "type": "string"
                         },
+                        "disableAutoUpdate": {
+                            "description": "Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.",
+                            "type": "boolean"
+                        },
+                        "maintenanceWindowStart": {
+                            "description": "Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.",
+                            "type": "integer"
+                        },
                         "verboseLogs": {
                             "description": "Toggle debug logging.",
                             "type": "boolean"

--- a/deployments/sdm-client/values.yaml
+++ b/deployments/sdm-client/values.yaml
@@ -14,6 +14,8 @@ strongdm:
 
   config: # @schema; description: General application configuration.
     appDomain: app.strongdm.com # @schema; description: Control plane to which to connect. Format `uk.strongdm.com`, etc.
+    disableAutoUpdate: false # @schema; description: Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
+    maintenanceWindowStart: 0 # @schema; description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
     verboseLogs: false # @schema; description: Toggle debug logging.
     additionalEnvVars: {} # @schema; description: Additional environment variables to add to the ConfigMap.
 


### PR DESCRIPTION
## Description of changes
allow clients to also auto update, feasible now after the previous change to the readiness check

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [ ] (optionally) deployed this change to k8s cluster.
