### PR TITLE
ensure unique cluster-scoped names so we can reuse release names

### DIFF
--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.5.0
+version: 2.5.1
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/clusterrole.yaml
+++ b/deployments/sdm-proxy/templates/clusterrole.yaml
@@ -5,7 +5,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-health
+  name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-health
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -22,7 +22,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-health
+  name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-health
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -44,7 +44,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-discovery
+  name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-discovery
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -75,7 +75,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-discovery
+  name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-discovery
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -97,7 +97,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-impersonate
+  name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-impersonate
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -115,7 +115,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-impersonate
+  name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-impersonate
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:

--- a/deployments/sdm-proxy/templates/clusterrole.yaml
+++ b/deployments/sdm-proxy/templates/clusterrole.yaml
@@ -5,8 +5,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "strongdm.name" . }}-health
-  namespace: {{ include "strongdm.namespace" . }}
+  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-health
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -23,8 +22,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "strongdm.name" . }}-health
-  namespace: {{ include "strongdm.namespace" . }}
+  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-health
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -46,8 +44,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "strongdm.name" . }}-discovery
-  namespace: {{ include "strongdm.namespace" . }}
+  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-discovery
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -78,8 +75,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "strongdm.name" . }}-discovery
-  namespace: {{ include "strongdm.namespace" . }}
+  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-discovery
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -101,8 +97,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "strongdm.name" . }}-impersonate
-  namespace: {{ include "strongdm.namespace" . }}
+  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-impersonate
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -120,8 +115,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "strongdm.name" . }}-impersonate
-  namespace: {{ include "strongdm.namespace" . }}
+  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-impersonate
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.4.0
+version: 2.4.1
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/clusterrole.yaml
+++ b/deployments/sdm-relay/templates/clusterrole.yaml
@@ -5,7 +5,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-health
+  name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-health
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -22,8 +22,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "strongdm.name" . }}-health
-  namespace: {{ include "strongdm.namespace" . }}
+  name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-health
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -45,7 +44,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-discovery
+  name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-discovery
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -76,8 +75,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "strongdm.name" . }}-discovery
-  namespace: {{ include "strongdm.namespace" . }}
+  name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-discovery
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -99,7 +97,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-impersonate
+  name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-impersonate
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -117,8 +115,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "strongdm.name" . }}-impersonate
-  namespace: {{ include "strongdm.namespace" . }}
+  name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-impersonate
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:

--- a/deployments/sdm-relay/templates/clusterrole.yaml
+++ b/deployments/sdm-relay/templates/clusterrole.yaml
@@ -5,8 +5,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "strongdm.name" . }}-health
-  namespace: {{ include "strongdm.namespace" . }}
+  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-health
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -46,8 +45,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "strongdm.name" . }}-discovery
-  namespace: {{ include "strongdm.namespace" . }}
+  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-discovery
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:
@@ -101,8 +99,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "strongdm.name" . }}-impersonate
-  namespace: {{ include "strongdm.namespace" . }}
+  name: {{ include "strongdm.name" . }}-{{ include "strongdm.namespace" . }}-impersonate
   annotations:
     {{- include "strongdm.annotations" . | nindent 4 }}
   labels:


### PR DESCRIPTION
## Description of changes
also omit `spec.metadata.namespace` on these resources as they're non-namespaced and the field is ignored.

there is some precedence here; for example, the AWS LB controller does this to allow for multiple installations in the same cluster.

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [ ] (optionally) deployed this change to k8s cluster.
