### PR TITLE
disable client auto updates again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,15 +120,6 @@ repos:
           == "true" ]]'
         language: system
         pass_filenames: false
-    -   id: template-tag-pin-client
-        name: Helm template | tag pin should disable SDM_DISABLE_UPDATE | client
-        entry: >
-          bash -c '[[ "$(helm template deployments/sdm-client -f deployments/sdm-client/values.test.yaml
-          --set strongdm.image.tag=100.10.0
-          | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")"
-          == "true" ]]'
-        language: system
-        pass_filenames: false
     -   id: template-digest-pin-relay
         name: Helm template | digest pin should disable SDM_DISABLE_UPDATE |
           relay
@@ -144,16 +135,6 @@ repos:
           proxy
         entry: >
           bash -c '[[ "$(helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.test.yaml
-          --set strongdm.image.digest=aaa
-          | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")"
-          == "true" ]]'
-        language: system
-        pass_filenames: false
-    -   id: template-digest-pin-client
-        name: Helm template | digest pin should disable SDM_DISABLE_UPDATE |
-          client
-        entry: >
-          bash -c '[[ "$(helm template deployments/sdm-client -f deployments/sdm-client/values.test.yaml
           --set strongdm.image.digest=aaa
           | yq -r ". | select(.kind == \"ConfigMap\") | .data.SDM_DISABLE_UPDATE")"
           == "true" ]]'

--- a/deployments/sdm-client/Chart.yaml
+++ b/deployments/sdm-client/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-client
 kubeVersion: '>= 1.16.0-0'
-version: 1.1.1
+version: 1.2.0
 description: StrongDM Client Container
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-client/templates/_helpers.tpl
+++ b/deployments/sdm-client/templates/_helpers.tpl
@@ -9,10 +9,6 @@
 {{- default (printf "app.%s" .Values.strongdm.config.domain) .Values.strongdm.config.appDomain }}
 {{- end }}
 
-{{- define "strongdm.disableAutoUpdate" -}}
-{{ (or .Values.strongdm.config.disableAutoUpdate (not (empty .Values.strongdm.image.digest)) (ne .Values.strongdm.image.tag "latest")) | quote }}
-{{- end }}
-
 # Args:
 # - addtl: (optional) map of annotations to add
 {{- define "strongdm.annotations" -}}

--- a/deployments/sdm-client/templates/configmap.yaml
+++ b/deployments/sdm-client/templates/configmap.yaml
@@ -10,8 +10,7 @@ metadata:
 data:
   SDM_APP_DOMAIN: {{ include "strongdm.appDomain" . }}
   SDM_VERBOSE: {{ .Values.strongdm.config.verboseLogs | quote }}
-  SDM_DISABLE_UPDATE: {{ include "strongdm.disableAutoUpdate" . }}
-  SDM_MAINTENANCE_WINDOW_START: {{ .Values.strongdm.config.maintenanceWindowStart | quote }}
+  SDM_DISABLE_UPDATE: "true"
   {{- range $k, $v := .Values.strongdm.config.additionalEnvVars }}
   {{ $k }}: {{ $v | quote }}
   {{- end }}

--- a/deployments/sdm-client/templates/deployment.yaml
+++ b/deployments/sdm-client/templates/deployment.yaml
@@ -49,13 +49,9 @@ spec:
           imagePullPolicy: {{ .Values.strongdm.image.pullPolicy }}
           {{- include "strongdm.resources" (dict "resources" .Values.strongdm.pod.resources) | nindent 10 }}
           livenessProbe:
-            {{- if (eq (include "strongdm.disableAutoUpdate" .) "true") }}
-            initialDelaySeconds: 60
-            {{- end }}
             exec:
               command: ["sdm", "ready"]
           readinessProbe:
-            initialDelaySeconds: 5
             exec:
               command: ["sdm", "ready"]
           env:


### PR DESCRIPTION
## Description of changes
disable auto updates for clients until we can dedicate more time to ensuring they don't just crash loop immediately

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [x] (optionally) deployed this change to k8s cluster.
