### PR TITLE
Add User subjects to ClusterRole bindings for healthcheck, discovery,…

### DIFF
--- a/deployments/sdm-proxy/templates/clusterrole.yaml
+++ b/deployments/sdm-proxy/templates/clusterrole.yaml
@@ -31,6 +31,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "strongdm.serviceAccountName" . }}
     namespace: {{ include "strongdm.namespace" . }}
+  - kind: User
+    name: healthcheck
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-health
@@ -84,6 +87,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "strongdm.serviceAccountName" . }}
     namespace: {{ include "strongdm.namespace" . }}
+  - kind: User
+    name: discovery
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-discovery
@@ -124,6 +130,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "strongdm.serviceAccountName" . }}
     namespace: {{ include "strongdm.namespace" . }}
+  - kind: User
+    name: impersonate
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-impersonate


### PR DESCRIPTION
Added User subjects to ClusterRole binding healthcheck, discovery, and impersonate templates. Enables the usage of the identity alias feature in SDM.

## Description of changes
Admins can now make use of both leased credentials & identity aliases after adding "user" subjects to each of the bindings. The helm chart did not support this by default, and forced admins to manually patch k8s configuration.

## Validation steps
Manually verified on app.strongdm.com that the cluster datasource continues to pass healthcheck after switching from leased credentials to identity aliases.

Logged into org and ran `kubectl get pods` on the k8s through SDM.