### PR TITLE
Fix discovery username

### DIFF
--- a/.github/workflows/helm-unittest.yml
+++ b/.github/workflows/helm-unittest.yml
@@ -1,0 +1,36 @@
+name: Helm Unit Tests (sdm-proxy)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'deployments/**'
+      - '.github/workflows/helm-unittest.yml'
+
+jobs:
+  helm-unittest:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.16.3'
+      
+      - name: Install helm unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+      
+      - name: Run helm unittest for sdm-proxy
+        run: |
+          cd deployments/sdm-proxy
+          helm unittest .
+      
+    #   - name: Upload test results
+    #     uses: actions/upload-artifact@v4
+    #     if: always()
+    #     with:
+    #       name: helm-unittest-results
+    #       path: deployments/sdm-proxy/tests/__snapshot__/ 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,11 +115,7 @@ repos:
         entry: /bin/bash -c '! helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.test.yaml --set strongdm.discoveryUsername=foobar --set strongdm.autoRegisterCluster.identitySetName=foobar'
         language: system
         pass_filenames: false
-    -   id: template-proxy-missing-discovery-username
-        name: Helm template | no discovery username when using Identity Aliases | proxy
-        entry: /bin/bash -c '! helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.test.yaml --set strongdm.healthcheckUsername=foobar --set strongdm.autoRegisterCluster.identitySetName=foobar'
-        language: system
-        pass_filenames: false
+
 
     # Check version pin paths
     -   id: template-tag-pin-relay

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -79,8 +79,10 @@ resources:
 {{- end }}
 {{- with .Values.strongdm.autoRegisterCluster }}
 {{ if (or .identitySet .identitySetName) -}}
---discovery-username {{ $.Values.strongdm.discoveryUsername }} \
 --identity-alias-healthcheck-username {{ $.Values.strongdm.healthcheckUsername }} \
+{{ if $.Values.strongdm.discoveryUsername -}}
+--discovery-username {{ $.Values.strongdm.discoveryUsername }}
+{{- end -}}
 {{ if .identitySet -}}
 --identity-set {{ .identitySet }}
 {{- else if .identitySetName -}}

--- a/deployments/sdm-proxy/templates/post-install.yaml
+++ b/deployments/sdm-proxy/templates/post-install.yaml
@@ -7,9 +7,6 @@
 {{- if (not .Values.strongdm.healthcheckUsername) }}
 {{- fail "@strongdm.healthcheckUsername must be set when either @strongdm.autoRegisterCluster.identitySet or @strongdm.autoRegisterCluster.identitySetName are set during installation." }}
 {{- end }}
-{{ if (not .Values.strongdm.discoveryUsername) }}
-{{- fail "@strongdm.discoveryUsername must be set when either @strongdm.autoRegisterCluster.identitySet or @strongdm.autoRegisterCluster.identitySetName are set during installation." }}
-{{- end }}
 {{- end }}
 ---
 apiVersion: batch/v1

--- a/deployments/sdm-proxy/tests/post-install_test.yaml
+++ b/deployments/sdm-proxy/tests/post-install_test.yaml
@@ -25,3 +25,30 @@ tests:
     asserts:
         - hasDocuments:
             count: 1
+
+  - it: a command for creating a cluster is with identity aliases only
+    set:
+      strongdm.auth.clusterKey: "test-key"
+      strongdm.auth.clusterSecret: "test-secret"
+      strongdm.auth.adminToken: "test-token"
+      strongdm.autoRegisterCluster.enabled: true
+      strongdm.autoRegisterCluster.identitySetName: "test-identity-set"
+      strongdm.healthcheckUsername: "test-healthcheck-user"
+    asserts:
+        - hasDocuments:
+            count: 1
+        - equal:
+            path: spec.template.spec.containers[0].name
+            value: sdm
+        - matchRegex:
+            path: spec.template.spec.containers[0].command[2]
+            pattern: '--identity-set-name test-identity-set'
+        - matchRegex:
+            path: spec.template.spec.containers[0].command[2]
+            pattern: '--identity-alias-healthcheck-username test-healthcheck-user'
+        - notMatchRegex:
+            path: spec.template.spec.containers[0].command[2]
+            pattern: '--discovery-enabled'
+        - notMatchRegex:
+            path: spec.template.spec.containers[0].command[2]
+            pattern: '--discovery-username'

--- a/deployments/sdm-proxy/tests/post-install_test.yaml
+++ b/deployments/sdm-proxy/tests/post-install_test.yaml
@@ -13,7 +13,7 @@ tests:
     asserts:
         - hasDocuments:
             count: 0
-  
+
   - it: should not require a discoveryUsername with identity aliases are used.
     set:
       strongdm.auth.clusterKey: "test-key"

--- a/deployments/sdm-proxy/tests/post-install_test.yaml
+++ b/deployments/sdm-proxy/tests/post-install_test.yaml
@@ -1,4 +1,4 @@
-suite: test sdm-proxy clusterrole RBAC conditions
+suite: test sdm-proxy post-install conditions
 templates:
   - post-install.yaml
 tests:
@@ -7,10 +7,21 @@ tests:
     set:
       strongdm.auth.clusterKey: "test-key"
       strongdm.auth.clusterSecret: "test-secret"
-      strongdm.auth.adminToken: "test-token"
       strongdm.autoRegisterCluster.enabled: false
       strongdm.autoRegisterCluster.identitySetName: "test-identity-set"
       strongdm.healthcheckUsername: "test-healthcheck-user"
     asserts:
         - hasDocuments:
-          count: 0
+            count: 0
+  
+  - it: should not require a discoveryUsername with identity aliases are used.
+    set:
+      strongdm.auth.clusterKey: "test-key"
+      strongdm.auth.clusterSecret: "test-secret"
+      strongdm.auth.adminToken: "test-token"
+      strongdm.autoRegisterCluster.enabled: true
+      strongdm.autoRegisterCluster.identitySetName: "test-identity-set"
+      strongdm.healthcheckUsername: "test-healthcheck-user"
+    asserts:
+        - hasDocuments:
+            count: 1

--- a/deployments/sdm-proxy/tests/post-install_test.yaml
+++ b/deployments/sdm-proxy/tests/post-install_test.yaml
@@ -1,0 +1,16 @@
+suite: test sdm-proxy clusterrole RBAC conditions
+templates:
+  - post-install.yaml
+tests:
+  # Basic RBAC without identity aliases
+  - it: should not be any CLI command if auto register is not used.
+    set:
+      strongdm.auth.clusterKey: "test-key"
+      strongdm.auth.clusterSecret: "test-secret"
+      strongdm.auth.adminToken: "test-token"
+      strongdm.autoRegisterCluster.enabled: false
+      strongdm.autoRegisterCluster.identitySetName: "test-identity-set"
+      strongdm.healthcheckUsername: "test-healthcheck-user"
+    asserts:
+        - hasDocuments:
+          count: 0

--- a/deployments/sdm-proxy/tests/rbac_clusterrole_test.yaml
+++ b/deployments/sdm-proxy/tests/rbac_clusterrole_test.yaml
@@ -93,4 +93,3 @@ tests:
           kind: ClusterRoleBinding
           name: NAMESPACE-RELEASE-NAME-discovery
           apiVersion: rbac.authorization.k8s.io/v1
-

--- a/deployments/sdm-proxy/tests/rbac_clusterrole_test.yaml
+++ b/deployments/sdm-proxy/tests/rbac_clusterrole_test.yaml
@@ -1,0 +1,65 @@
+suite: test sdm-proxy clusterrole RBAC conditions
+templates:
+  - clusterrole.yaml
+tests:
+  # Basic RBAC without identity aliases
+  - it: should create basic health and discovery RBAC without identity aliases
+    set:
+      strongdm.auth.clusterKey: "test-key"
+      strongdm.auth.clusterSecret: "test-secret"
+    asserts:
+      - hasDocuments:
+          count: 4
+      - containsDocument:
+          kind: ClusterRole
+          name: NAMESPACE-RELEASE-NAME-health
+          apiVersion: rbac.authorization.k8s.io/v1
+      - containsDocument:
+          kind: ClusterRoleBinding
+          name: NAMESPACE-RELEASE-NAME-health
+          apiVersion: rbac.authorization.k8s.io/v1
+      - containsDocument:
+          kind: ClusterRole
+          name: NAMESPACE-RELEASE-NAME-discovery
+          apiVersion: rbac.authorization.k8s.io/v1
+      - containsDocument:
+          kind: ClusterRoleBinding
+          name: NAMESPACE-RELEASE-NAME-discovery
+          apiVersion: rbac.authorization.k8s.io/v1
+
+
+  - it: should not create impersonation RBAC without identity set
+    set:
+      strongdm.auth.clusterKey: "test-key"
+      strongdm.auth.clusterSecret: "test-secret"
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: should only include service account in subjects without identity aliases
+    set:
+      strongdm.auth.clusterKey: "test-key"
+      strongdm.auth.clusterSecret: "test-secret"
+    documentIndex: 1  # health ClusterRoleBinding
+    asserts:
+      - equal:
+          path: subjects
+          value:
+            - kind: ServiceAccount
+              name: RELEASE-NAME
+              namespace: NAMESPACE
+
+  - it: should contain the user subject with identity aliases
+    set:
+      strongdm.auth.clusterKey: "test-key"
+      strongdm.auth.clusterSecret: "test-secret"
+      strongdm.autoRegisterCluster.identitySet: "test-identity-set"
+      strongdm.healthcheckUsername: "test-healthcheck-user"
+    documentIndex: 1  # health ClusterRoleBinding
+    asserts:
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[1].kind
+          value: User

--- a/deployments/sdm-proxy/tests/rbac_clusterrole_test.yaml
+++ b/deployments/sdm-proxy/tests/rbac_clusterrole_test.yaml
@@ -53,6 +53,8 @@ tests:
     set:
       strongdm.auth.clusterKey: "test-key"
       strongdm.auth.clusterSecret: "test-secret"
+      strongdm.auth.adminToken: "test-token"
+      strongdm.autoRegisterCluster.enabled: true
       strongdm.autoRegisterCluster.identitySet: "test-identity-set"
       strongdm.healthcheckUsername: "test-healthcheck-user"
     documentIndex: 1  # health ClusterRoleBinding
@@ -63,3 +65,32 @@ tests:
       - equal:
           path: subjects[1].kind
           value: User
+
+  - it: should create basic health and discovery RBAC without identity aliases
+    set:
+      strongdm.auth.clusterKey: "test-key"
+      strongdm.auth.clusterSecret: "test-secret"
+      strongdm.auth.adminToken: "test-token"
+      strongdm.autoRegisterCluster.enabled: true
+      strongdm.autoRegisterCluster.identitySetName: "test-identity-set"
+      strongdm.healthcheckUsername: "test-healthcheck-user"
+    asserts:
+      - hasDocuments:
+          count: 6
+      - containsDocument:
+          kind: ClusterRole
+          name: NAMESPACE-RELEASE-NAME-health
+          apiVersion: rbac.authorization.k8s.io/v1
+      - containsDocument:
+          kind: ClusterRoleBinding
+          name: NAMESPACE-RELEASE-NAME-health
+          apiVersion: rbac.authorization.k8s.io/v1
+      - containsDocument:
+          kind: ClusterRole
+          name: NAMESPACE-RELEASE-NAME-discovery
+          apiVersion: rbac.authorization.k8s.io/v1
+      - containsDocument:
+          kind: ClusterRoleBinding
+          name: NAMESPACE-RELEASE-NAME-discovery
+          apiVersion: rbac.authorization.k8s.io/v1
+


### PR DESCRIPTION
## Description of changes
Discovered a bug w/ the post-install templating. The discovery-username was being added as an argument whenever identity aliases were being used. Discovery does not depend on identity aliases, but identity aliases is coupled to discovery username if it is enabled.

## Validation steps
Added unit tests. Removed a pre commit hook which was validating the buggy behavior.