### PR TITLE
fix newlines when templating post-install SDM CLI command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,12 +102,12 @@ repos:
         pass_filenames: false
     -   id: template-relay-missing-healthcheck-username
         name: Helm template | no healthcheck username when using Identity Aliases | relay
-        entry: /bin/bash -c '! helm template deployments/sdm-relay -f deployments/sdm-relay/values.test.yaml --set strongdm.discoveryUsername=foobar --set strongdm.autoRegisterCluster.identitySetName=foobar'
+        entry: /bin/bash -c '! helm template deployments/sdm-relay -f deployments/sdm-relay/values.test.yaml --set strongdm.autoRegisterCluster.identitySetName=foobar'
         language: system
         pass_filenames: false
     -   id: template-proxy-missing-healthcheck-username
         name: Helm template | no healthcheck username when using Identity Aliases | proxy
-        entry: /bin/bash -c '! helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.test.yaml --set strongdm.discoveryUsername=foobar --set strongdm.autoRegisterCluster.identitySetName=foobar'
+        entry: /bin/bash -c '! helm template deployments/sdm-proxy -f deployments/sdm-proxy/values.test.yaml --set strongdm.autoRegisterCluster.identitySetName=foobar'
         language: system
         pass_filenames: false
 

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.6.1
+version: 2.6.2
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -74,20 +74,21 @@ resources:
 
 {{- define "strongdm.autoRegisterClusterArgs" -}}
 --healthcheck-namespace {{ .Values.strongdm.healthcheckNamespace }} \
-{{ if .Values.strongdm.discoveryUsername -}}
+{{- if .Values.strongdm.discoveryUsername }}
 --discovery-enabled \
-{{- end }}
+{{- end -}}
 {{- with .Values.strongdm.autoRegisterCluster }}
 {{ if (or .identitySet .identitySetName) -}}
 --identity-alias-healthcheck-username {{ $.Values.strongdm.healthcheckUsername }} \
-{{ if $.Values.strongdm.discoveryUsername -}}
+{{- if $.Values.strongdm.discoveryUsername }}
 --discovery-username {{ $.Values.strongdm.discoveryUsername }} \
-{{- end -}}
+{{- end }}
 {{ if .identitySet -}}
---identity-set {{ .identitySet }}
+--identity-set {{ .identitySet }} \
 {{- else if .identitySetName -}}
---identity-set-name {{ .identitySetName }}
+--identity-set-name {{ .identitySetName }} \
 {{- end -}}
 {{- end -}}
-{{- end -}}
+{{- end }}
+{{ .Values.strongdm.autoRegisterCluster.extraArgs }}
 {{- end }}

--- a/deployments/sdm-proxy/templates/_helpers.tpl
+++ b/deployments/sdm-proxy/templates/_helpers.tpl
@@ -78,14 +78,14 @@ resources:
 --discovery-enabled \
 {{- end -}}
 {{- with .Values.strongdm.autoRegisterCluster }}
-{{ if (or .identitySet .identitySetName) -}}
+{{- if (or .identitySet .identitySetName) }}
 --identity-alias-healthcheck-username {{ $.Values.strongdm.healthcheckUsername }} \
 {{- if $.Values.strongdm.discoveryUsername }}
 --discovery-username {{ $.Values.strongdm.discoveryUsername }} \
 {{- end }}
-{{ if .identitySet -}}
+{{- if .identitySet }}
 --identity-set {{ .identitySet }} \
-{{- else if .identitySetName -}}
+{{- else if .identitySetName }}
 --identity-set-name {{ .identitySetName }} \
 {{- end -}}
 {{- end -}}

--- a/deployments/sdm-proxy/templates/post-install.yaml
+++ b/deployments/sdm-proxy/templates/post-install.yaml
@@ -61,6 +61,5 @@ spec:
               /sdm.linux admin clusters add k8spodidentity \
                 --certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 {{- include "strongdm.autoRegisterClusterArgs" . | nindent 16 }} \
-                {{ .Values.strongdm.autoRegisterCluster.extraArgs }} \
                 {{ default (printf "%s-cluster-%s" (include "strongdm.name" .) (randAlpha 5)) .Values.strongdm.autoRegisterCluster.resourceName }}
 {{- end}}

--- a/deployments/sdm-proxy/values.test.yaml
+++ b/deployments/sdm-proxy/values.test.yaml
@@ -18,7 +18,6 @@ strongdm:
     create: true
   autoRegisterCluster:
     enabled: true
-    extraArgs: '--foo bar --bar=baz -f -b'
   config:
     additionalEnvVars:
       foo: bar

--- a/deployments/sdm-proxy/values.test.yaml
+++ b/deployments/sdm-proxy/values.test.yaml
@@ -6,17 +6,19 @@ global:
   labels:
     foo: bar
   annotations:
-    foo.com/bar: baz
+    foo.bar/baz: sure
 
 strongdm:
+  discoveryUsername: bar
   auth:
-    adminToken: foo
-    clusterKey: foo
-    clusterSecret: foo
+    adminToken: foo.bar.baz
+    clusterKey: foo.bar.baz
+    clusterSecret: foo.bar.baz
   serviceAccount:
     create: true
   autoRegisterCluster:
     enabled: true
+    extraArgs: '--foo bar --bar=baz -f -b'
   config:
     additionalEnvVars:
       foo: bar

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.5.1
+version: 2.5.2
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -78,20 +78,21 @@ resources:
 
 {{- define "strongdm.autoRegisterClusterArgs" -}}
 --healthcheck-namespace {{ .Values.strongdm.healthcheckNamespace }} \
-{{ if .Values.strongdm.discoveryUsername -}}
+{{- if .Values.strongdm.discoveryUsername }}
 --discovery-enabled \
-{{- end }}
+{{- end -}}
 {{- with .Values.strongdm.autoRegisterCluster }}
 {{ if (or .identitySet .identitySetName) -}}
 --identity-alias-healthcheck-username {{ $.Values.strongdm.healthcheckUsername }} \
-{{ if $.Values.strongdm.discoveryUsername -}}
+{{- if $.Values.strongdm.discoveryUsername }}
 --discovery-username {{ $.Values.strongdm.discoveryUsername }} \
-{{- end -}}
+{{- end }}
 {{ if .identitySet -}}
---identity-set {{ .identitySet }}
+--identity-set {{ .identitySet }} \
 {{- else if .identitySetName -}}
---identity-set-name {{ .identitySetName }}
+--identity-set-name {{ .identitySetName }} \
 {{- end -}}
 {{- end -}}
-{{- end -}}
+{{- end }}
+{{ .Values.strongdm.autoRegisterCluster.extraArgs }}
 {{- end }}

--- a/deployments/sdm-relay/templates/_helpers.tpl
+++ b/deployments/sdm-relay/templates/_helpers.tpl
@@ -82,14 +82,14 @@ resources:
 --discovery-enabled \
 {{- end -}}
 {{- with .Values.strongdm.autoRegisterCluster }}
-{{ if (or .identitySet .identitySetName) -}}
+{{- if (or .identitySet .identitySetName) }}
 --identity-alias-healthcheck-username {{ $.Values.strongdm.healthcheckUsername }} \
 {{- if $.Values.strongdm.discoveryUsername }}
 --discovery-username {{ $.Values.strongdm.discoveryUsername }} \
 {{- end }}
-{{ if .identitySet -}}
+{{- if .identitySet }}
 --identity-set {{ .identitySet }} \
-{{- else if .identitySetName -}}
+{{- else if .identitySetName }}
 --identity-set-name {{ .identitySetName }} \
 {{- end -}}
 {{- end -}}

--- a/deployments/sdm-relay/templates/post-install.yaml
+++ b/deployments/sdm-relay/templates/post-install.yaml
@@ -61,6 +61,5 @@ spec:
               /sdm.linux admin clusters add k8spodidentity \
                 --certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 {{- include "strongdm.autoRegisterClusterArgs" . | nindent 16 }} \
-                {{ .Values.strongdm.autoRegisterCluster.extraArgs }} \
                 {{ default (printf "%s-cluster-%s" (include "strongdm.name" .) (randAlpha 5)) .Values.strongdm.autoRegisterCluster.resourceName }}
 {{- end}}

--- a/deployments/sdm-relay/values.test.yaml
+++ b/deployments/sdm-relay/values.test.yaml
@@ -6,15 +6,17 @@ global:
   labels:
     foo: bar
   annotations:
-    foo.com/bar: baz
+    foo.bar/baz: sure
 
 strongdm:
+  discoveryUsername: bar
   auth:
     adminToken: foo.bar.baz
   serviceAccount:
     create: true
   autoRegisterCluster:
     enabled: true
+    extraArgs: '--foo bar --bar=baz -f -b'
   config:
     additionalEnvVars:
       foo: bar

--- a/deployments/sdm-relay/values.test.yaml
+++ b/deployments/sdm-relay/values.test.yaml
@@ -16,7 +16,6 @@ strongdm:
     create: true
   autoRegisterCluster:
     enabled: true
-    extraArgs: '--foo bar --bar=baz -f -b'
   config:
     additionalEnvVars:
       foo: bar


### PR DESCRIPTION
## Description of changes
on some combinations of inputs, the post-install SDM CLI command was invalid, specifically including extra whitespace like:
```bash
/sdm.linux admin clusters add k8spodidentity \
                --certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                --healthcheck-namespace default \
                 \

                 \
                release-name-cluster-zLZnY
```

this change removes the extra whitespace and cleans up the command a bit by also moving the extra args into the helper function.

## Validation steps
- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [x] templated locally with all input combos I could think of
