### PR TITLE
83 bug default image does not template correctly

### DIFF
--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.5.3
+version: 2.5.4
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/pre-install.yaml
+++ b/deployments/sdm-relay/templates/pre-install.yaml
@@ -134,7 +134,7 @@ spec:
       containers:
         - name: kubectl
           {{- $kubeVersion := semver .Capabilities.KubeVersion.Version }}
-          image: {{ default (printf "bitnami/kubectl:%s.%s" $kubeVersion.Major $kubeVersion.Minor) .Values.strongdm.autoCreateNode.kubectlImage }}
+          image: {{ default (printf "bitnami/kubectl:%d.%d" $kubeVersion.Major $kubeVersion.Minor) .Values.strongdm.autoCreateNode.kubectlImage }}
           imagePullPolicy: IfNotPresent
           resources:
             requests:


### PR DESCRIPTION
## Description of changes
Corrected templating to correctly specify a default bitnami image for sdm-relay

## Validation steps
Before change:
```
[HW-0368:sdm-relay] on 83-bug-default-image-does-not-template-correctly!
[anthony.volkov]% helm template test-relay . --set strongdm.autoCreateNode.enabled=true --set strongdm.auth.adminToken=dummy-token | grep -i bit
          image: bitnami/kubectl:%!s(uint64=1).%!s(uint64=31)
```
After change:
```
[HW-0368:sdm-relay] on 83-bug-default-image-does-not-template-correctly!
[anthony.volkov]% helm template test-relay . --set strongdm.autoCreateNode.enabled=true --set strongdm.auth.adminToken=dummy-token | grep -i bit
          image: bitnami/kubectl:1.31
```

- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [ ] (optionally) deployed this change to k8s cluster.
