### PR TITLE
Feat optional rbac

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -162,10 +162,10 @@ repos:
     hooks:
     -   id: helm-schema
         name: helm-schema | relay
-        args: ["-input", "deployments/sdm-relay/values.yaml", "-output", "deployments/sdm-relay/values.schema.json"]
+        args: ["-f", "deployments/sdm-relay/values.yaml", "-o", "deployments/sdm-relay/values.schema.json"]
     -   id: helm-schema
         name: helm-schema | proxy
-        args: ["-input", "deployments/sdm-proxy/values.yaml", "-output", "deployments/sdm-proxy/values.schema.json"]
+        args: ["-f", "deployments/sdm-proxy/values.yaml", "-o", "deployments/sdm-proxy/values.schema.json"]
     -   id: helm-schema
         name: helm-schema | client
-        args: ["-input", "deployments/sdm-client/values.yaml", "-output", "deployments/sdm-client/values.schema.json"]
+        args: ["-f", "deployments/sdm-client/values.yaml", "-o", "deployments/sdm-client/values.schema.json"]

--- a/deployments/sdm-client/values.schema.json
+++ b/deployments/sdm-client/values.schema.json
@@ -1,25 +1,26 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
     "properties": {
         "global": {
+            "type": "object",
             "properties": {
                 "annotations": {
                     "description": "Map of annotations to add to all resources.",
-                    "properties": {},
                     "type": "object"
                 },
                 "labels": {
                     "description": "Map of labels to add to all resources.",
-                    "properties": {},
                     "type": "object"
                 }
-            },
-            "type": "object"
+            }
         },
         "strongdm": {
+            "type": "object",
             "properties": {
                 "auth": {
                     "description": "StrongDM authentication sources.",
+                    "type": "object",
                     "properties": {
                         "secretName": {
                             "description": "Name of the k8s Secret that contains SDM_SERVICE_TOKEN.",
@@ -29,15 +30,14 @@
                             "description": "The SDM_SERVICE_TOKEN with which to authenticate this StrongDM client. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.",
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "config": {
                     "description": "General application configuration.",
+                    "type": "object",
                     "properties": {
                         "additionalEnvVars": {
                             "description": "Additional environment variables to add to the ConfigMap.",
-                            "properties": {},
                             "type": "object"
                         },
                         "appDomain": {
@@ -56,25 +56,22 @@
                             "description": "Toggle debug logging.",
                             "type": "boolean"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "deployment": {
                     "description": "Deployment configuration.",
+                    "type": "object",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to add to the Deployment.",
-                            "properties": {},
                             "type": "object"
                         },
                         "labels": {
                             "description": "Map of labels to add to the Deployment.",
-                            "properties": {},
                             "type": "object"
                         },
                         "nodeSelector": {
                             "description": "Pod node selectors.",
-                            "properties": {},
                             "type": "object"
                         },
                         "replicaCount": {
@@ -87,8 +84,10 @@
                         },
                         "topologySpreadConstraints": {
                             "description": "Pod spread constraints. Keys in this map are topology keys. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.",
+                            "type": "object",
                             "properties": {
                                 "kubernetes.io/hostname": {
+                                    "type": "object",
                                     "properties": {
                                         "maxSkew": {
                                             "type": "integer"
@@ -96,17 +95,15 @@
                                         "whenUnsatisfiable": {
                                             "type": "string"
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 }
-                            },
-                            "type": "object"
+                            }
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "image": {
                     "description": "Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.",
+                    "type": "object",
                     "properties": {
                         "digest": {
                             "type": "string"
@@ -120,8 +117,7 @@
                         "tag": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "nameOverride": {
                     "description": "Override resource names.",
@@ -133,29 +129,30 @@
                 },
                 "pod": {
                     "description": "Pod configuration.",
+                    "type": "object",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to add to Pods.",
-                            "properties": {},
                             "type": "object"
                         },
                         "labels": {
                             "description": "Map of labels to add to Pods.",
-                            "properties": {},
                             "type": "object"
                         },
                         "resources": {
                             "description": "Set the Pod resource requests and limits.",
+                            "type": "object",
                             "properties": {
                                 "limits": {
+                                    "type": "object",
                                     "properties": {
                                         "memory": {
                                             "type": "string"
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 },
                                 "requests": {
+                                    "type": "object",
                                     "properties": {
                                         "cpu": {
                                             "type": "string"
@@ -163,18 +160,13 @@
                                         "memory": {
                                             "type": "string"
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 }
-                            },
-                            "type": "object"
+                            }
                         }
-                    },
-                    "type": "object"
+                    }
                 }
-            },
-            "type": "object"
+            }
         }
-    },
-    "type": "object"
+    }
 }

--- a/deployments/sdm-client/values.yaml
+++ b/deployments/sdm-client/values.yaml
@@ -1,43 +1,43 @@
 global:
-  annotations: {} # @schema; description: Map of annotations to add to all resources.
-  labels: {} # @schema; description: Map of labels to add to all resources.
+  annotations: {} # @schema description: Map of annotations to add to all resources.
+  labels: {} # @schema description: Map of labels to add to all resources.
 
 strongdm:
-  nameOverride: "" # @schema; description: Override resource names.
-  namespaceOverride: "" # @schema; description: Override the release namespace.
+  nameOverride: "" # @schema description: Override resource names.
+  namespaceOverride: "" # @schema description: Override the release namespace.
 
-  image: # @schema; description: Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
+  image: # @schema description: Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
     pullPolicy: IfNotPresent
     repository: public.ecr.aws/strongdm/client
     tag: latest
     digest: ""
 
-  config: # @schema; description: General application configuration.
-    appDomain: app.strongdm.com # @schema; description: Control plane to which to connect. Format `uk.strongdm.com`, etc.
-    disableAutoUpdate: false # @schema; description: Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
-    maintenanceWindowStart: 0 # @schema; description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
-    verboseLogs: false # @schema; description: Toggle debug logging.
-    additionalEnvVars: {} # @schema; description: Additional environment variables to add to the ConfigMap.
+  config: # @schema description: General application configuration.
+    appDomain: app.strongdm.com # @schema description: Control plane to which to connect. Format `uk.strongdm.com`, etc.
+    disableAutoUpdate: false # @schema description: Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
+    maintenanceWindowStart: 0 # @schema description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
+    verboseLogs: false # @schema description: Toggle debug logging.
+    additionalEnvVars: {} # @schema description: Additional environment variables to add to the ConfigMap.
 
-  auth: # @schema; description: StrongDM authentication sources.
-    serviceToken: "" # @schema; description: The SDM_SERVICE_TOKEN with which to authenticate this StrongDM client. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
-    secretName: "" # @schema; description: Name of the k8s Secret that contains SDM_SERVICE_TOKEN.
+  auth: # @schema description: StrongDM authentication sources.
+    serviceToken: "" # @schema description: The SDM_SERVICE_TOKEN with which to authenticate this StrongDM client. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+    secretName: "" # @schema description: Name of the k8s Secret that contains SDM_SERVICE_TOKEN.
 
-  deployment: # @schema; description: Deployment configuration.
-    annotations: {} # @schema; description: Map of annotations to add to the Deployment.
-    labels: {} # @schema; description: Map of labels to add to the Deployment.
-    replicaCount: 1 # @schema; description: Number of Pods to run in the deployment.
-    nodeSelector: {} # @schema; description: Pod node selectors.
-    tolerations: [] # @schema; description: Pod node tolerations.
-    topologySpreadConstraints: # @schema; description: Pod spread constraints. Keys in this map are topology keys. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.
+  deployment: # @schema description: Deployment configuration.
+    annotations: {} # @schema description: Map of annotations to add to the Deployment.
+    labels: {} # @schema description: Map of labels to add to the Deployment.
+    replicaCount: 1 # @schema description: Number of Pods to run in the deployment.
+    nodeSelector: {} # @schema description: Pod node selectors.
+    tolerations: [] # @schema description: Pod node tolerations.
+    topologySpreadConstraints: # @schema description: Pod spread constraints. Keys in this map are topology keys. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.
       kubernetes.io/hostname:
         maxSkew: 1
         whenUnsatisfiable: ScheduleAnyway
 
-  pod: # @schema; description: Pod configuration.
-    annotations: {} # @schema; description: Map of annotations to add to Pods.
-    labels: {} # @schema; description: Map of labels to add to Pods.
-    resources: # @schema; description: Set the Pod resource requests and limits.
+  pod: # @schema description: Pod configuration.
+    annotations: {} # @schema description: Map of annotations to add to Pods.
+    labels: {} # @schema description: Map of labels to add to Pods.
+    resources: # @schema description: Set the Pod resource requests and limits.
       requests:
         memory: 2Gi
         cpu: 512m

--- a/deployments/sdm-proxy/Chart.yaml
+++ b/deployments/sdm-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-proxy
 kubeVersion: ">= 1.16.0-0"
-version: 2.6.6
+version: 2.7.6
 description: StrongDM Proxy
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-proxy/templates/clusterrole.yaml
+++ b/deployments/sdm-proxy/templates/clusterrole.yaml
@@ -1,6 +1,7 @@
 # ###
 # Health
 # ###
+{{- if .Values.strongdm.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -138,4 +139,5 @@ roleRef:
   kind: ClusterRole
   name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-impersonate
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/deployments/sdm-proxy/templates/role.yaml
+++ b/deployments/sdm-proxy/templates/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.strongdm.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -42,3 +43,4 @@ roleRef:
   kind: Role
   name: {{ include "strongdm.name" . }}-health
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deployments/sdm-proxy/values.schema.json
+++ b/deployments/sdm-proxy/values.schema.json
@@ -1,25 +1,26 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
     "properties": {
         "global": {
+            "type": "object",
             "properties": {
                 "annotations": {
                     "description": "Map of annotations to add to all resources.",
-                    "properties": {},
                     "type": "object"
                 },
                 "labels": {
                     "description": "Map of labels to add to all resources.",
-                    "properties": {},
                     "type": "object"
                 }
-            },
-            "type": "object"
+            }
         },
         "strongdm": {
+            "type": "object",
             "properties": {
                 "auth": {
                     "description": "StrongDM authentication sources.",
+                    "type": "object",
                     "properties": {
                         "adminToken": {
                             "description": "The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.",
@@ -37,11 +38,11 @@
                             "description": "Name of the k8s Secret that contains SDM_PROXY_CLUSTER_ACCESS_KEY and SDM_PROXY_CLUSTER_SECRET_KEY, and/or SDM_ADMIN_TOKEN.",
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "autoRegisterCluster": {
                     "description": "Cluster auto-registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.",
+                    "type": "object",
                     "properties": {
                         "enabled": {
                             "description": "Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.",
@@ -63,15 +64,14 @@
                             "description": "Name of the StrongDM Pod Identity Cluster resource to create.",
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "config": {
                     "description": "General application configuration.",
+                    "type": "object",
                     "properties": {
                         "additionalEnvVars": {
                             "description": "Additional environment variables to add to the ConfigMap.",
-                            "properties": {},
                             "type": "object"
                         },
                         "appDomain": {
@@ -96,45 +96,42 @@
                         },
                         "queryLogs": {
                             "description": "Query logging options, disabled by default. See https://www.strongdm.com/docs/admin/logs for more information.",
+                            "type": "object",
                             "properties": {
                                 "encoding": {
-                                    "description": "Query log encoding",
+                                    "description": "Query log encoding - options: 'plaintext', 'publickey'.",
                                     "type": "string"
                                 },
                                 "format": {
-                                    "description": "Query log format",
+                                    "description": "Query log format - options: 'json', 'csv'.",
                                     "type": "string"
                                 },
                                 "storage": {
-                                    "description": "Query log storage location",
+                                    "description": "Query log storage location - options: 'stdout', 'tcp', 'syslog', 'socket', 'file'. The default is to disable the additional audit logs.",
                                     "type": "string"
                                 }
-                            },
-                            "type": "object"
+                            }
                         },
                         "verboseLogs": {
                             "description": "Toggle debug logging.",
                             "type": "boolean"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "deployment": {
                     "description": "Deployment configuration.",
+                    "type": "object",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to add to the Deployment.",
-                            "properties": {},
                             "type": "object"
                         },
                         "labels": {
                             "description": "Map of labels to add to the Deployment.",
-                            "properties": {},
                             "type": "object"
                         },
                         "nodeSelector": {
                             "description": "Pod node selectors.",
-                            "properties": {},
                             "type": "object"
                         },
                         "replicaCount": {
@@ -147,8 +144,10 @@
                         },
                         "topologySpreadConstraints": {
                             "description": "Pod spread constraints. Keys in this map are topology keys. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.",
+                            "type": "object",
                             "properties": {
                                 "kubernetes.io/hostname": {
+                                    "type": "object",
                                     "properties": {
                                         "maxSkew": {
                                             "type": "integer"
@@ -156,14 +155,11 @@
                                         "whenUnsatisfiable": {
                                             "type": "string"
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 }
-                            },
-                            "type": "object"
+                            }
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "discoveryUsername": {
                     "description": "Username for StrongDM discovery. Also creates the RBAC resources required for this feature. Required if either @strongdm.autoRegisterCluster.identitySet or @strongdm.autoRegisterCluster.identitySetName are set.",
@@ -179,6 +175,7 @@
                 },
                 "image": {
                     "description": "Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.",
+                    "type": "object",
                     "properties": {
                         "digest": {
                             "type": "string"
@@ -192,8 +189,7 @@
                         "tag": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "nameOverride": {
                     "description": "Override resource names.",
@@ -205,29 +201,30 @@
                 },
                 "pod": {
                     "description": "Pod configuration.",
+                    "type": "object",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to add to Pods.",
-                            "properties": {},
                             "type": "object"
                         },
                         "labels": {
                             "description": "Map of labels to add to Pods.",
-                            "properties": {},
                             "type": "object"
                         },
                         "resources": {
                             "description": "Set the Pod resource requests and limits.",
+                            "type": "object",
                             "properties": {
                                 "limits": {
+                                    "type": "object",
                                     "properties": {
                                         "memory": {
                                             "type": "string"
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 },
                                 "requests": {
+                                    "type": "object",
                                     "properties": {
                                         "cpu": {
                                             "type": "string"
@@ -235,21 +232,28 @@
                                         "memory": {
                                             "type": "string"
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 }
-                            },
-                            "type": "object"
+                            }
                         }
-                    },
-                    "type": "object"
+                    }
+                },
+                "rbac": {
+                    "description": "RBAC configuration.",
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "description": "Create a Role/ClusterRole. Set to true, or manage RBAC externally.",
+                            "type": "boolean"
+                        }
+                    }
                 },
                 "service": {
                     "description": "Service configuration.",
+                    "type": "object",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to apply to the Service.",
-                            "properties": {},
                             "type": "object"
                         },
                         "containerPort": {
@@ -258,7 +262,6 @@
                         },
                         "labels": {
                             "description": "Map of labels to apply to the Service.",
-                            "properties": {},
                             "type": "object"
                         },
                         "listenPort": {
@@ -275,8 +278,11 @@
                         },
                         "selectorLabels": {
                             "description": "Map of additional selector labels to apply to Pods and the Service.",
-                            "properties": {},
                             "type": "object"
+                        },
+                        "tlsClientAuth": {
+                            "description": "How this service is expected to validate TLS client certificates, if at all. Set this to `none` if the load balancer is terminating TLS and re-establishing a new TLS connection to the worker.",
+                            "type": "string"
                         },
                         "tlsSecretName": {
                             "description": "kubernetes.io/tls Secret with which containers will terminate TLS.",
@@ -290,15 +296,14 @@
                             "description": "Specify the type of Service to front the deployment.",
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "serviceAccount": {
                     "description": "ServiceAccount configuration.",
+                    "type": "object",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to add to the ServiceAccount, should one be created.",
-                            "properties": {},
                             "type": "object"
                         },
                         "create": {
@@ -307,19 +312,15 @@
                         },
                         "labels": {
                             "description": "Map of labels to add to the ServiceAccount, should one be created.",
-                            "properties": {},
                             "type": "object"
                         },
                         "name": {
                             "description": "Name of an existing ServiceAccount to use.",
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 }
-            },
-            "type": "object"
+            }
         }
-    },
-    "type": "object"
+    }
 }

--- a/deployments/sdm-proxy/values.test.yaml
+++ b/deployments/sdm-proxy/values.test.yaml
@@ -23,3 +23,5 @@ strongdm:
       foo: bar
       bar: 2
       baz: false
+  rbac:
+    create: true

--- a/deployments/sdm-proxy/values.yaml
+++ b/deployments/sdm-proxy/values.yaml
@@ -1,83 +1,86 @@
 global:
-  annotations: {} # @schema; description: Map of annotations to add to all resources.
-  labels: {} # @schema; description: Map of labels to add to all resources.
+  annotations: {} # @schema description: Map of annotations to add to all resources.
+  labels: {} # @schema description: Map of labels to add to all resources.
 
 strongdm:
-  nameOverride: "" # @schema; description: Override resource names.
-  namespaceOverride: "" # @schema; description: Override the release namespace.
+  nameOverride: "" # @schema description: Override resource names.
+  namespaceOverride: "" # @schema description: Override the release namespace.
 
-  image: # @schema; description: Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
+  image: # @schema description: Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
     pullPolicy: IfNotPresent
     repository: public.ecr.aws/strongdm/relay
     tag: latest
     digest: ""
 
-  config: # @schema; description: General application configuration.
-    domain: strongdm.com # @schema; description: (DEPRECATED) control plane to which to connect. Format `uk.strongdm.com`, etc.
-    appDomain: app.strongdm.com # @schema; description: Control plane to which to connect. Format `uk.strongdm.com`, etc.
-    disableAutoUpdate: false # @schema; description: Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
-    maintenanceWindowStart: 0 # @schema; description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
-    enableMetrics: false # @schema; description: Enable Prometheus metrics on port 9999.
-    verboseLogs: false # @schema; description: Toggle debug logging.
-    queryLogs: # @schema; description: Query logging options, disabled by default. See https://www.strongdm.com/docs/admin/logs for more information.
-      storage: "" # @schema; description: Query log storage location; options: 'stdout', 'tcp', 'syslog', 'socket', 'file'. The default is to disable the additional audit logs.
-      format: "" # @schema; description: Query log format; options: 'json', 'csv'.
-      encoding: "" # @schema; description: Query log encoding; options: 'plaintext', 'publickey'
-    additionalEnvVars: {} # @schema; description: Additional environment variables to add to the ConfigMap.
+  config: # @schema description: General application configuration.
+    domain: strongdm.com # @schema description: (DEPRECATED) control plane to which to connect. Format `uk.strongdm.com`, etc.
+    appDomain: app.strongdm.com # @schema description: Control plane to which to connect. Format `uk.strongdm.com`, etc.
+    disableAutoUpdate: false # @schema description: Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
+    maintenanceWindowStart: 0 # @schema description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
+    enableMetrics: false # @schema description: Enable Prometheus metrics on port 9999.
+    verboseLogs: false # @schema description: Toggle debug logging.
+    queryLogs: # @schema description: Query logging options, disabled by default. See https://www.strongdm.com/docs/admin/logs for more information.
+      storage: "" # @schema description: Query log storage location - options: 'stdout', 'tcp', 'syslog', 'socket', 'file'. The default is to disable the additional audit logs.
+      format: "" # @schema description: Query log format - options: 'json', 'csv'.
+      encoding: "" # @schema description: Query log encoding - options: 'plaintext', 'publickey'.
+    additionalEnvVars: {} # @schema description: Additional environment variables to add to the ConfigMap.
 
-  discoveryUsername: "" # @schema; description: Username for StrongDM discovery. Also creates the RBAC resources required for this feature. Required if either @strongdm.autoRegisterCluster.identitySet or @strongdm.autoRegisterCluster.identitySetName are set.
-  healthcheckUsername: "" # @schema; description: Username for StrongDM resource health checks. Used in the RBAC resources that facilitate said health checks. Required if either @strongdm.autoRegisterCluster.identitySet or @strongdm.autoRegisterCluster.identitySetName are set.
-  healthcheckNamespace: default # @schema; description: Namespace in which StrongDM resource health checks are to occur. Associated/required RBAC resources are created in this namespace.
+  discoveryUsername: "" # @schema description: Username for StrongDM discovery. Also creates the RBAC resources required for this feature. Required if either @strongdm.autoRegisterCluster.identitySet or @strongdm.autoRegisterCluster.identitySetName are set.
+  healthcheckUsername: "" # @schema description: Username for StrongDM resource health checks. Used in the RBAC resources that facilitate said health checks. Required if either @strongdm.autoRegisterCluster.identitySet or @strongdm.autoRegisterCluster.identitySetName are set.
+  healthcheckNamespace: default # @schema description: Namespace in which StrongDM resource health checks are to occur. Associated/required RBAC resources are created in this namespace.
 
-  autoRegisterCluster: # @schema; description: Cluster auto-registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
-    enabled: false # @schema; description: Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
-    resourceName: "" # @schema; description: Name of the StrongDM Pod Identity Cluster resource to create.
-    identitySet: "" # @schema; description: ID of the Identity Set with which to register this cluster.
-    identitySetName: "" # @schema; description: Name of the Identity Set with which to register this cluster.
-    extraArgs: "" # @schema; description: Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.
+  autoRegisterCluster: # @schema description: Cluster auto-registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
+    enabled: false # @schema description: Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
+    resourceName: "" # @schema description: Name of the StrongDM Pod Identity Cluster resource to create.
+    identitySet: "" # @schema description: ID of the Identity Set with which to register this cluster.
+    identitySetName: "" # @schema description: Name of the Identity Set with which to register this cluster.
+    extraArgs: "" # @schema description: Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.
 
-  auth: # @schema; description: StrongDM authentication sources.
-    clusterKey: "" # @schema; description: The SDM_PROXY_CLUSTER_ACCESS_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
-    clusterSecret: "" # @schema; description: The SDM_PROXY_CLUSTER_SECRET_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
-    adminToken: "" # @schema; description: The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
-    secretName: "" # @schema; description: Name of the k8s Secret that contains SDM_PROXY_CLUSTER_ACCESS_KEY and SDM_PROXY_CLUSTER_SECRET_KEY, and/or SDM_ADMIN_TOKEN.
+  auth: # @schema description: StrongDM authentication sources.
+    clusterKey: "" # @schema description: The SDM_PROXY_CLUSTER_ACCESS_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+    clusterSecret: "" # @schema description: The SDM_PROXY_CLUSTER_SECRET_KEY with which this proxy should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+    adminToken: "" # @schema description: The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+    secretName: "" # @schema description: Name of the k8s Secret that contains SDM_PROXY_CLUSTER_ACCESS_KEY and SDM_PROXY_CLUSTER_SECRET_KEY, and/or SDM_ADMIN_TOKEN.
 
-  service: # @schema; description: Service configuration.
-    annotations: {} # @schema; description: Map of annotations to apply to the Service.
-    labels: {} # @schema; description: Map of labels to apply to the Service.
-    selectorLabels: {} # @schema; description: Map of additional selector labels to apply to Pods and the Service.
-    type: ClusterIP # @schema; description: Specify the type of Service to front the deployment.
-    listenPort: 443 # @schema; description: Port on which the container runs.
-    containerPort: 8443 # @schema; description: Port on which the Service is expecting traffic.
-    nodePort: 0 # @schema; description: NodePort to which to bind this service, if desired.
-    loadBalancerIP: "" # @schema; description: IP address to which to pin a LoadBalancer Service.
-    tlsSource: "" # @schema; description: How this service is expected to terminate TLS, if at all. Set to `file` and supply @strongdm.service.tlsSecretName to terminate with a user-provided certificate. Set to `none` if terminating TLS before these containers, e.g. with a load balancer. Leave empty to terminate TLS with a StrongDM-signed certificate built into the software.
-    tlsSecretName: "" # @schema; description: kubernetes.io/tls Secret with which containers will terminate TLS.
-    tlsClientAuth: "" # @schema; description: How this service is expected to validate TLS client certificates, if at all. Set this to `none` if the load balancer is terminating TLS and re-establishing a new TLS connection to the worker.
+  service: # @schema description: Service configuration.
+    annotations: {} # @schema description: Map of annotations to apply to the Service.
+    labels: {} # @schema description: Map of labels to apply to the Service.
+    selectorLabels: {} # @schema description: Map of additional selector labels to apply to Pods and the Service.
+    type: ClusterIP # @schema description: Specify the type of Service to front the deployment.
+    listenPort: 443 # @schema description: Port on which the container runs.
+    containerPort: 8443 # @schema description: Port on which the Service is expecting traffic.
+    nodePort: 0 # @schema description: NodePort to which to bind this service, if desired.
+    loadBalancerIP: "" # @schema description: IP address to which to pin a LoadBalancer Service.
+    tlsSource: "" # @schema description: How this service is expected to terminate TLS, if at all. Set to `file` and supply @strongdm.service.tlsSecretName to terminate with a user-provided certificate. Set to `none` if terminating TLS before these containers, e.g. with a load balancer. Leave empty to terminate TLS with a StrongDM-signed certificate built into the software.
+    tlsSecretName: "" # @schema description: kubernetes.io/tls Secret with which containers will terminate TLS.
+    tlsClientAuth: "" # @schema description: How this service is expected to validate TLS client certificates, if at all. Set this to `none` if the load balancer is terminating TLS and re-establishing a new TLS connection to the worker.
 
-  deployment: # @schema; description: Deployment configuration.
-    annotations: {} # @schema; description: Map of annotations to add to the Deployment.
-    labels: {} # @schema; description: Map of labels to add to the Deployment.
-    replicaCount: 2 # @schema; description: Number of Pods to run in the deployment.
-    nodeSelector: {} # @schema; description: Pod node selectors.
-    tolerations: [] # @schema; description: Pod node tolerations.
-    topologySpreadConstraints: # @schema; description: Pod spread constraints. Keys in this map are topology keys. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.
+  deployment: # @schema description: Deployment configuration.
+    annotations: {} # @schema description: Map of annotations to add to the Deployment.
+    labels: {} # @schema description: Map of labels to add to the Deployment.
+    replicaCount: 2 # @schema description: Number of Pods to run in the deployment.
+    nodeSelector: {} # @schema description: Pod node selectors.
+    tolerations: [] # @schema description: Pod node tolerations.
+    topologySpreadConstraints: # @schema description: Pod spread constraints. Keys in this map are topology keys. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for more info.
       kubernetes.io/hostname:
         maxSkew: 1
         whenUnsatisfiable: ScheduleAnyway
 
-  pod: # @schema; description: Pod configuration.
-    annotations: {} # @schema; description: Map of annotations to add to Pods.
-    labels: {} # @schema; description: Map of labels to add to Pods.
-    resources: # @schema; description: Set the Pod resource requests and limits.
+  pod: # @schema description: Pod configuration.
+    annotations: {} # @schema description: Map of annotations to add to Pods.
+    labels: {} # @schema description: Map of labels to add to Pods.
+    resources: # @schema description: Set the Pod resource requests and limits.
       requests:
         memory: 2560Mi
         cpu: 1024m
       limits:
         memory: 2560Mi
 
-  serviceAccount: # @schema; description: ServiceAccount configuration.
-    create: true # @schema; description: Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not use a ServiceAccount.
-    name: "" # @schema; description: Name of an existing ServiceAccount to use.
-    annotations: {} # @schema; description: Map of annotations to add to the ServiceAccount, should one be created.
-    labels: {} # @schema; description: Map of labels to add to the ServiceAccount, should one be created.
+  serviceAccount: # @schema description: ServiceAccount configuration.
+    create: true # @schema description: Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not use a ServiceAccount.
+    name: "" # @schema description: Name of an existing ServiceAccount to use.
+    annotations: {} # @schema description: Map of annotations to add to the ServiceAccount, should one be created.
+    labels: {} # @schema description: Map of labels to add to the ServiceAccount, should one be created.
+
+  rbac: # @schema description: RBAC configuration.
+    create: true # @schema description: Create a Role/ClusterRole. Set to true, or manage RBAC externally.

--- a/deployments/sdm-relay/Chart.yaml
+++ b/deployments/sdm-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sdm-relay
 kubeVersion: ">= 1.16.0-0"
-version: 2.5.4
+version: 2.6.4
 description: StrongDM Relay
 type: application
 icon: https://raw.githubusercontent.com/strongdm/charts/main/sdm_icon.png

--- a/deployments/sdm-relay/templates/clusterrole.yaml
+++ b/deployments/sdm-relay/templates/clusterrole.yaml
@@ -1,6 +1,7 @@
 # ###
 # Health
 # ###
+{{- if .Values.strongdm.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -138,4 +139,5 @@ roleRef:
   kind: ClusterRole
   name: {{ include "strongdm.namespace" . }}-{{ include "strongdm.name" . }}-impersonate
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/deployments/sdm-relay/templates/role.yaml
+++ b/deployments/sdm-relay/templates/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.strongdm.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -42,3 +43,4 @@ roleRef:
   kind: Role
   name: {{ include "strongdm.name" . }}-health
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deployments/sdm-relay/values.schema.json
+++ b/deployments/sdm-relay/values.schema.json
@@ -1,25 +1,26 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
     "properties": {
         "global": {
+            "type": "object",
             "properties": {
                 "annotations": {
                     "description": "Map of annotations to add to all resources.",
-                    "properties": {},
                     "type": "object"
                 },
                 "labels": {
                     "description": "Map of labels to add to all resources.",
-                    "properties": {},
                     "type": "object"
                 }
-            },
-            "type": "object"
+            }
         },
         "strongdm": {
+            "type": "object",
             "properties": {
                 "auth": {
                     "description": "StrongDM authentication sources.",
+                    "type": "object",
                     "properties": {
                         "adminToken": {
                             "description": "The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.",
@@ -33,11 +34,11 @@
                             "description": "Name of the k8s Secret that contains SDM_RELAY_TOKEN and/or SDM_ADMIN_TOKEN.",
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "autoCreateNode": {
                     "description": "Auto creation configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.",
+                    "type": "object",
                     "properties": {
                         "enabled": {
                             "description": "Create this StrongDM Relay or Gateway automatically.",
@@ -48,7 +49,7 @@
                             "type": "string"
                         },
                         "maintenanceWindows": {
-                            "description": "Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6",
+                            "description": "Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. \"* 7 * * 0,6\",\"* * * * *\".",
                             "type": "string"
                         },
                         "name": {
@@ -59,11 +60,11 @@
                             "description": "Tags to add to the created Node. Format 'key=value,key2=value2'.",
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "autoRegisterCluster": {
                     "description": "Cluster auto-registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.",
+                    "type": "object",
                     "properties": {
                         "enabled": {
                             "description": "Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.",
@@ -85,15 +86,14 @@
                             "description": "Name of the StrongDM Pod Identity Cluster resource to create.",
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "config": {
                     "description": "General application configuration.",
+                    "type": "object",
                     "properties": {
                         "additionalEnvVars": {
                             "description": "Additional environment variables to add to the ConfigMap.",
-                            "properties": {},
                             "type": "object"
                         },
                         "appDomain": {
@@ -118,53 +118,49 @@
                         },
                         "queryLogs": {
                             "description": "Query logging options, disabled by default. See https://www.strongdm.com/docs/admin/logs for more information.",
+                            "type": "object",
                             "properties": {
                                 "encoding": {
-                                    "description": "Query log encoding",
+                                    "description": "Query log encoding - options: 'plaintext', 'publickey'",
                                     "type": "string"
                                 },
                                 "format": {
-                                    "description": "Query log format",
+                                    "description": "Query log format - options: 'json', 'csv'.",
                                     "type": "string"
                                 },
                                 "storage": {
-                                    "description": "Query log storage location",
+                                    "description": "Query log storage location - options: 'stdout', 'tcp', 'syslog', 'socket', 'file'.",
                                     "type": "string"
                                 }
-                            },
-                            "type": "object"
+                            }
                         },
                         "verboseLogs": {
                             "description": "Toggle debug logging.",
                             "type": "boolean"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "deployment": {
                     "description": "Deployment configuration.",
+                    "type": "object",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to add to the Deployment.",
-                            "properties": {},
                             "type": "object"
                         },
                         "labels": {
                             "description": "Map of labels to add to the Deployment.",
-                            "properties": {},
                             "type": "object"
                         },
                         "nodeSelector": {
                             "description": "Pod node selectors.",
-                            "properties": {},
                             "type": "object"
                         },
                         "tolerations": {
                             "description": "Pod node tolerations.",
                             "type": "array"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "discoveryUsername": {
                     "description": "Username for StrongDM discovery. Also creates the RBAC resources required for this feature. Required if either @strongdm.autoRegisterCluster.identitySet or @strongdm.autoRegisterCluster.identitySetName are set.",
@@ -172,6 +168,7 @@
                 },
                 "gateway": {
                     "description": "StrongDM Gateway configuration. See https://www.strongdm.com/docs/admin/nodes for more information.",
+                    "type": "object",
                     "properties": {
                         "containerPort": {
                             "description": "Port on which the container runs.",
@@ -191,15 +188,14 @@
                         },
                         "service": {
                             "description": "Service configuration. Ignored unless @strongdm.gateway.enabled.",
+                            "type": "object",
                             "properties": {
                                 "annotations": {
                                     "description": "Map of annotations to apply to the Service.",
-                                    "properties": {},
                                     "type": "object"
                                 },
                                 "labels": {
                                     "description": "Map of labels to apply to the Service.",
-                                    "properties": {},
                                     "type": "object"
                                 },
                                 "nodePort": {
@@ -208,18 +204,15 @@
                                 },
                                 "selectorLabels": {
                                     "description": "Service selector labels.",
-                                    "properties": {},
                                     "type": "object"
                                 },
                                 "type": {
                                     "description": "Specify the type of Service to front the deployment.",
                                     "type": "string"
                                 }
-                            },
-                            "type": "object"
+                            }
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "healthcheckNamespace": {
                     "description": "Namespace in which StrongDM resource health checks are to occur. Associated/required RBAC resources are created in this namespace.",
@@ -231,6 +224,7 @@
                 },
                 "image": {
                     "description": "Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.",
+                    "type": "object",
                     "properties": {
                         "digest": {
                             "type": "string"
@@ -244,8 +238,7 @@
                         "tag": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "nameOverride": {
                     "description": "Override resource names.",
@@ -257,29 +250,30 @@
                 },
                 "pod": {
                     "description": "Pod configuration.",
+                    "type": "object",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to add to Pods.",
-                            "properties": {},
                             "type": "object"
                         },
                         "labels": {
                             "description": "Map of labels to add to Pods.",
-                            "properties": {},
                             "type": "object"
                         },
                         "resources": {
                             "description": "Set the Pod resource requests and limits.",
+                            "type": "object",
                             "properties": {
                                 "limits": {
+                                    "type": "object",
                                     "properties": {
                                         "memory": {
                                             "type": "string"
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 },
                                 "requests": {
+                                    "type": "object",
                                     "properties": {
                                         "cpu": {
                                             "type": "string"
@@ -287,21 +281,28 @@
                                         "memory": {
                                             "type": "string"
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 }
-                            },
-                            "type": "object"
+                            }
                         }
-                    },
-                    "type": "object"
+                    }
+                },
+                "rbac": {
+                    "description": "RBAC configuration.",
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "description": "Create a Role/ClusterRole. Set to true, or manage RBAC externally",
+                            "type": "boolean"
+                        }
+                    }
                 },
                 "serviceAccount": {
                     "description": "ServiceAccount configuration.",
+                    "type": "object",
                     "properties": {
                         "annotations": {
                             "description": "Map of annotations to add to the ServiceAccount, should one be created.",
-                            "properties": {},
                             "type": "object"
                         },
                         "create": {
@@ -310,19 +311,15 @@
                         },
                         "labels": {
                             "description": "Map of labels to add to the ServiceAccount, should one be created.",
-                            "properties": {},
                             "type": "object"
                         },
                         "name": {
                             "description": "Name of an existing ServiceAccount to use.",
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 }
-            },
-            "type": "object"
+            }
         }
-    },
-    "type": "object"
+    }
 }

--- a/deployments/sdm-relay/values.test.yaml
+++ b/deployments/sdm-relay/values.test.yaml
@@ -21,3 +21,5 @@ strongdm:
       foo: bar
       bar: 2
       baz: false
+  rbac:
+    create: true

--- a/deployments/sdm-relay/values.yaml
+++ b/deployments/sdm-relay/values.yaml
@@ -1,83 +1,86 @@
 global:
-  annotations: {} # @schema; description: Map of annotations to add to all resources.
-  labels: {} # @schema; description: Map of labels to add to all resources.
+  annotations: {} # @schema description: Map of annotations to add to all resources.
+  labels: {} # @schema description: Map of labels to add to all resources.
 
 strongdm:
-  nameOverride: "" # @schema; description: Override resource names.
-  namespaceOverride: "" # @schema; description: Override the release namespace.
+  nameOverride: "" # @schema description: Override resource names.
+  namespaceOverride: "" # @schema description: Override the release namespace.
 
-  image: # @schema; description: Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
+  image: # @schema description: Container repository and pull config. If @strongdm.image.tag or @strongdm.image.digest are set, SDM_DISABLE_UPDATE is set to `true`.
     pullPolicy: IfNotPresent
     repository: public.ecr.aws/strongdm/relay
     tag: latest
     digest: ""
 
-  config: # @schema; description: General application configuration.
-    domain: strongdm.com # @schema; description: (DEPRECATED) control plane to which to connect. Format `uk.strongdm.com`, etc.
-    appDomain: app.strongdm.com # @schema; description: Control plane to which to connect. Format `uk.strongdm.com`, etc.
-    disableAutoUpdate: false # @schema; description: Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
-    maintenanceWindowStart: 0 # @schema; description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
-    enableMetrics: false # @schema; description: Enable Prometheus metrics on port 9999.
-    verboseLogs: false # @schema; description: Toggle debug logging.
-    queryLogs: # @schema; description: Query logging options, disabled by default. See https://www.strongdm.com/docs/admin/logs for more information.
-      storage: "" # @schema; description: Query log storage location; options: 'stdout', 'tcp', 'syslog', 'socket', 'file'.
-      format: "" # @schema; description: Query log format; options: 'json', 'csv'.
-      encoding: "" # @schema; description: Query log encoding; options: 'plaintext', 'publickey'
-    additionalEnvVars: {} # @schema; description: Additional environment variables to add to the ConfigMap.
+  config: # @schema description: General application configuration.
+    domain: strongdm.com # @schema description: (DEPRECATED) control plane to which to connect. Format `uk.strongdm.com`, etc.
+    appDomain: app.strongdm.com # @schema description: Control plane to which to connect. Format `uk.strongdm.com`, etc.
+    disableAutoUpdate: false # @schema description: Disable automatically checking for and applying updates. Implicitly set to `true` if @strongdm.image.tag or @strongdm.image.digest are supplied.
+    maintenanceWindowStart: 0 # @schema description: Hour of the day (0-23 UTC) to terminate connections and restart when applying updates.
+    enableMetrics: false # @schema description: Enable Prometheus metrics on port 9999.
+    verboseLogs: false # @schema description: Toggle debug logging.
+    queryLogs: # @schema description: Query logging options, disabled by default. See https://www.strongdm.com/docs/admin/logs for more information.
+      storage: "" # @schema description: Query log storage location - options: 'stdout', 'tcp', 'syslog', 'socket', 'file'.
+      format: "" # @schema description: Query log format - options: 'json', 'csv'.
+      encoding: "" # @schema description: Query log encoding - options: 'plaintext', 'publickey'
+    additionalEnvVars: {} # @schema description: Additional environment variables to add to the ConfigMap.
 
-  discoveryUsername: "" # @schema; description: Username for StrongDM discovery. Also creates the RBAC resources required for this feature. Required if either @strongdm.autoRegisterCluster.identitySet or @strongdm.autoRegisterCluster.identitySetName are set.
-  healthcheckUsername: "" # @schema; description: Username for StrongDM resource health checks. Used in the RBAC resources that facilitate said health checks. Required if either @strongdm.autoRegisterCluster.identitySet or @strongdm.autoRegisterCluster.identitySetName are set.
-  healthcheckNamespace: default # @schema; description: Namespace in which StrongDM resource health checks are to occur. Associated/required RBAC resources are created in this namespace.
+  discoveryUsername: "" # @schema description: Username for StrongDM discovery. Also creates the RBAC resources required for this feature. Required if either @strongdm.autoRegisterCluster.identitySet or @strongdm.autoRegisterCluster.identitySetName are set.
+  healthcheckUsername: "" # @schema description: Username for StrongDM resource health checks. Used in the RBAC resources that facilitate said health checks. Required if either @strongdm.autoRegisterCluster.identitySet or @strongdm.autoRegisterCluster.identitySetName are set.
+  healthcheckNamespace: default # @schema description: Namespace in which StrongDM resource health checks are to occur. Associated/required RBAC resources are created in this namespace.
 
-  autoRegisterCluster: # @schema; description: Cluster auto-registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
-    enabled: false # @schema; description: Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
-    resourceName: "" # @schema; description: Name of the StrongDM Pod Identity Cluster resource to create.
-    identitySet: "" # @schema; description: ID of the Identity Set with which to register this cluster.
-    identitySetName: "" # @schema; description: Name of the Identity Set with which to register this cluster.
-    extraArgs: "" # @schema; description: Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.
+  autoRegisterCluster: # @schema description: Cluster auto-registration configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
+    enabled: false # @schema description: Register this k8s cluster as a StrongDM Pod Identity Cluster. See https://www.strongdm.com/docs/admin/resources/clusters/kubernetes-podidentity/ for more information.
+    resourceName: "" # @schema description: Name of the StrongDM Pod Identity Cluster resource to create.
+    identitySet: "" # @schema description: ID of the Identity Set with which to register this cluster.
+    identitySetName: "" # @schema description: Name of the Identity Set with which to register this cluster.
+    extraArgs: "" # @schema description: Space-separated string of args to pass to the `sdm admin clusters add k8spodidentity` command.
 
-  autoCreateNode: # @schema; description: Auto creation configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
-    enabled: true # @schema; description: Create this StrongDM Relay or Gateway automatically.
-    name: "" # @schema; description: Name of the Node as it should appear in StrongDM.
-    tags: "" # @schema; description: Tags to add to the created Node. Format 'key=value,key2=value2'.
-    maintenanceWindows: '* * * * *' # @schema; description: Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. '* 7 * * 0,6;* * * * *'.
-    kubectlImage: "" # @schema; description: Full URI of the container with kubectl installed, used to create a k8s Secret. Defaults to a bitnami/kubectl image.
+  autoCreateNode: # @schema description: Auto creation configuration. Requires SDM_ADMIN_TOKEN be provided via one of the supported @strongdm.auth methods.
+    enabled: true # @schema description: Create this StrongDM Relay or Gateway automatically.
+    name: "" # @schema description: Name of the Node as it should appear in StrongDM.
+    tags: "" # @schema description: Tags to add to the created Node. Format 'key=value,key2=value2'.
+    maintenanceWindows: '* * * * *' # @schema description: Semicolon-separated cron schedules, the first group being the hard-cutoff group e.g. "* 7 * * 0,6","* * * * *".
+    kubectlImage: "" # @schema description: Full URI of the container with kubectl installed, used to create a k8s Secret. Defaults to a bitnami/kubectl image.
 
-  auth: # @schema; description: StrongDM authentication sources.
-    relayToken: "" # @schema; description: The SDM_RELAY_TOKEN with which this relay should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
-    adminToken: "" # @schema; description: The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
-    secretName: "" # @schema; description: Name of the k8s Secret that contains SDM_RELAY_TOKEN and/or SDM_ADMIN_TOKEN.
+  auth: # @schema description: StrongDM authentication sources.
+    relayToken: "" # @schema description: The SDM_RELAY_TOKEN with which this relay should authenticate itself. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+    adminToken: "" # @schema description: The SDM_ADMIN_TOKEN with which to create StrongDM resources. Specify this directly, or provide an existing secret to @strongdm.auth.secretName.
+    secretName: "" # @schema description: Name of the k8s Secret that contains SDM_RELAY_TOKEN and/or SDM_ADMIN_TOKEN.
 
-  gateway: # @schema; description: StrongDM Gateway configuration. See https://www.strongdm.com/docs/admin/nodes for more information.
-    enabled: false # @schema; description: Whether this is to be a StrongDM Gateway. If false, a Relay is created, and all other @strongdm.gateway values are ignored.
-    listenAddress: "" # @schema; description: Address at which the Gateway expects traffic. Ignored unless @strongdm.autoCreateNode.enabled.
-    listenPort: 5000 # @schema; description: Port on which the Gateway expects traffic.
-    containerPort: 5000 # @schema; description: Port on which the container runs.
-    service: # @schema; description: Service configuration. Ignored unless @strongdm.gateway.enabled.
-      annotations: {} # @schema; description: Map of annotations to apply to the Service.
-      labels: {} # @schema; description: Map of labels to apply to the Service.
-      selectorLabels: {} # @schema; description: Service selector labels.
-      type: ClusterIP # @schema; description: Specify the type of Service to front the deployment.
-      nodePort: 0 # @schema; description: NodePort to which to bind this service, if desired.
+  gateway: # @schema description: StrongDM Gateway configuration. See https://www.strongdm.com/docs/admin/nodes for more information.
+    enabled: false # @schema description: Whether this is to be a StrongDM Gateway. If false, a Relay is created, and all other @strongdm.gateway values are ignored.
+    listenAddress: "" # @schema description: Address at which the Gateway expects traffic. Ignored unless @strongdm.autoCreateNode.enabled.
+    listenPort: 5000 # @schema description: Port on which the Gateway expects traffic.
+    containerPort: 5000 # @schema description: Port on which the container runs.
+    service: # @schema description: Service configuration. Ignored unless @strongdm.gateway.enabled.
+      annotations: {} # @schema description: Map of annotations to apply to the Service.
+      labels: {} # @schema description: Map of labels to apply to the Service.
+      selectorLabels: {} # @schema description: Service selector labels.
+      type: ClusterIP # @schema description: Specify the type of Service to front the deployment.
+      nodePort: 0 # @schema description: NodePort to which to bind this service, if desired.
 
-  deployment: # @schema; description: Deployment configuration.
-    annotations: {} # @schema; description: Map of annotations to add to the Deployment.
-    labels: {} # @schema; description: Map of labels to add to the Deployment.
-    nodeSelector: {} # @schema; description: Pod node selectors.
-    tolerations: [] # @schema; description: Pod node tolerations.
+  deployment: # @schema description: Deployment configuration.
+    annotations: {} # @schema description: Map of annotations to add to the Deployment.
+    labels: {} # @schema description: Map of labels to add to the Deployment.
+    nodeSelector: {} # @schema description: Pod node selectors.
+    tolerations: [] # @schema description: Pod node tolerations.
 
-  pod: # @schema; description: Pod configuration.
-    annotations: {} # @schema; description: Map of annotations to add to Pods.
-    labels: {} # @schema; description: Map of labels to add to Pods.
-    resources: # @schema; description: Set the Pod resource requests and limits.
+  pod: # @schema description: Pod configuration.
+    annotations: {} # @schema description: Map of annotations to add to Pods.
+    labels: {} # @schema description: Map of labels to add to Pods.
+    resources: # @schema description: Set the Pod resource requests and limits.
       requests:
         memory: 2560Mi
         cpu: 1024m
       limits:
         memory: 2560Mi
 
-  serviceAccount: # @schema; description: ServiceAccount configuration.
-    create: true # @schema; description: Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not use a ServiceAccount.
-    name: "" # @schema; description: Name of an existing ServiceAccount to use.
-    annotations: {} # @schema; description: Map of annotations to add to the ServiceAccount, should one be created.
-    labels: {} # @schema; description: Map of labels to add to the ServiceAccount, should one be created.
+  serviceAccount: # @schema description: ServiceAccount configuration.
+    create: true # @schema description: Create a ServiceAccount. Set to true, or specify and existing ServiceAccount with @strongdm.serviceAccount.name. Do neither to not use a ServiceAccount.
+    name: "" # @schema description: Name of an existing ServiceAccount to use.
+    annotations: {} # @schema description: Map of annotations to add to the ServiceAccount, should one be created.
+    labels: {} # @schema description: Map of labels to add to the ServiceAccount, should one be created.
+
+  rbac: # @schema description: RBAC configuration.
+    create: true # @schema description: Create a Role/ClusterRole. Set to true, or manage RBAC externally


### PR DESCRIPTION
## Description of changes
Make it possible for SDM RBAC to be externally-managed outside helm chart by introducing `.Values.strongdm.rbac.create` in strongdm-proxy and strongdm-relay. The value defaults to `true` to not introduce breaking change.

This should close #96 

Additionally:
- update the config of `helm-values-schema-json` hook in `.pre-commit-config.yaml` to respect plugin version 2.3.1
- update all inline annotation syntax in `**/values.yaml` to generate description properly based on plugin version 2.3.1

## Validation steps
Note that the changes in `**/values.schema.json` are generated during pre-commit stage of helm-values-schema-json. 

- [x] installed the [pre-commit](https://pre-commit.com) hooks with `pre-commit install`
- [] (optionally) deployed this change to k8s cluster.
